### PR TITLE
fix(greeter): mulit-user fingerprint login

### DIFF
--- a/session-widgets/lockworker.h
+++ b/session-widgets/lockworker.h
@@ -54,6 +54,7 @@ private:
     void lockServiceEvent(quint32 eventType, quint32 pid, const QString &username, const QString &message);
     void onUnlockFinished(bool unlocked);
     // greeter
+    void userAuthForLightdm(std::shared_ptr<User> user);
     void prompt(QString text, QLightDM::Greeter::PromptType type);
     void message(QString text, QLightDM::Greeter::MessageType type);
     void authenticationComplete();


### PR DESCRIPTION
greeter启动后会进入认证状态，如果使用的是指纹验证，并不会调用，因为需要手动调用一下greeter的respond方法。

TODO： 当用户A使用指纹时进行用户切换，认证失败的提示将会显示在用户B这里，考虑以后把错误信息封装在User类中，这样LockContent和UserInputWidget可以根据用户来显示错误。