### PR TITLE
refactor(Shutdown): change keyReleaseEvent to keyPressEvent

### DIFF
--- a/dde-shutdown/view/contentwidget.cpp
+++ b/dde-shutdown/view/contentwidget.cpp
@@ -136,7 +136,7 @@ void ContentWidget::showEvent(QShowEvent *event)
     }
 }
 
-void ContentWidget::keyReleaseEvent(QKeyEvent *event)
+void ContentWidget::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {
     case Qt::Key_Escape: onCancel(); break;

--- a/dde-shutdown/view/contentwidget.h
+++ b/dde-shutdown/view/contentwidget.h
@@ -66,7 +66,7 @@ signals:
 protected:
     void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
     void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
-    void keyReleaseEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
+    void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
     void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
     void hideEvent(QHideEvent *event) Q_DECL_OVERRIDE;
 


### PR DESCRIPTION
现在dde-shutdown是后台常驻，再次显示出来会非常快，通过命令行调用会导致界面收到了松开按键的事件。