### PR TITLE
修复无密码登录无法解锁

### DIFF
--- a/libdde-auth/deepinauthframework.cpp
+++ b/libdde-auth/deepinauthframework.cpp
@@ -31,12 +31,7 @@ void DeepinAuthFramework::Authenticate()
     m_fprint->SetUser(USERNAME);
 
     // It takes time to auth again after cancel!
-    QTimer::singleShot(100, this, [=] {
-        if (!PASSWORD.isEmpty()) {
-            m_keyboard->Authenticate();
-        }
-    });
-
+    QTimer::singleShot(100, m_keyboard, &AuthAgent::Authenticate);
     QTimer::singleShot(500, m_fprint, &AuthAgent::Authenticate);
 }
 

--- a/session-widgets/lockworker.h
+++ b/session-widgets/lockworker.h
@@ -48,7 +48,6 @@ private:
     void onLoginUserListChanged(const QString &list);
     bool checkHaveDisplay(const QJsonArray &array);
     bool isLogined(uint uid);
-    bool checkUserIsNoPWGrp(std::shared_ptr<User> user);
     void onCurrentUserChanged(const QString &user);
 
     void saveNumlockStatus(std::shared_ptr<User> user, const bool &on);

--- a/session-widgets/sessionbasemodel.cpp
+++ b/session-widgets/sessionbasemodel.cpp
@@ -126,9 +126,11 @@ void SessionBaseModel::setIsShow(bool isShow)
 
     m_isShow = isShow;
 
+#ifndef QT_DEBUG
     if (m_sessionManagerInter && m_currentType == LockType) {
         m_sessionManagerInter->SetLocked(m_isShow);
     }
+#endif
 
     emit visibleChanged(isShow);
 }

--- a/session-widgets/userinfo.h
+++ b/session-widgets/userinfo.h
@@ -46,8 +46,7 @@ public:
     const QString locale() const { return m_locale; }
     void setLocale(const QString &locale);
 
-    bool isNoPasswdGrp() const { return m_isNoPasswdGrp; }
-    void setNoPasswdGrp(bool nopassword);
+    bool isNoPasswdGrp() const;
 
     void setisLogind(bool isLogind);
     virtual void setCurrentLayout(const QString &layout) { Q_UNUSED(layout); }
@@ -73,7 +72,6 @@ protected:
 
 protected:
     bool m_isLogind;
-    bool m_isNoPasswdGrp;
     bool m_isLock;
     uint m_uid;
     uint m_lockNum; // minute basis

--- a/session-widgets/userinputwidget.cpp
+++ b/session-widgets/userinputwidget.cpp
@@ -182,27 +182,7 @@ void UserInputWidget::setUser(std::shared_ptr<User> user)
     m_passwordEdit->hide();
     m_otherUserInput->hide();
 
-    int frameHeight = (m_userAvatar->height() + 20 + m_nameLbl->height() + 18) * 2;
-
-    if (user->type() == User::ADDomain && user->uid() == 0) {
-        m_passwordEdit->hide();
-        m_otherUserInput->show();
-        frameHeight += m_otherUserInput->height();
-        m_otherUserInput->setFocus();
-    }
-    else if (user->type() == User::ADDomain) {
-        m_passwordEdit->show();
-        frameHeight += DDESESSIONCC::PASSWDLINEEDIT_HEIGHT;
-        grabKeyboard();
-    }
-    else {
-        setIsNoPasswordGrp(user->isNoPasswdGrp());
-        updateKBLayout(user->kbLayoutList());
-        setDefaultKBLayout(user->currentKBLayout());
-        frameHeight += DDESESSIONCC::PASSWDLINEEDIT_HEIGHT;
-    }
-
-    setFixedHeight(frameHeight);
+    refreshInputState();
 }
 
 void UserInputWidget::setName(const QString &name)
@@ -385,6 +365,13 @@ void UserInputWidget::resizeEvent(QResizeEvent *event)
     return QWidget::resizeEvent(event);
 }
 
+void UserInputWidget::showEvent(QShowEvent *event)
+{
+    refreshInputState();
+
+    return QWidget::showEvent(event);
+}
+
 void UserInputWidget::refreshLanguage()
 {
     for (auto it = m_trList.begin(); it != m_trList.end(); ++it) {
@@ -434,6 +421,31 @@ void UserInputWidget::refreshKBLayoutWidgetPosition()
                                                                          m_passwordEdit->geometry().bottomLeft().y() - 15));
     m_kbLayoutBorder->move(point.x(), point.y());
     m_kbLayoutBorder->setArrowX(15);
+}
+
+void UserInputWidget::refreshInputState()
+{
+    int frameHeight = (m_userAvatar->height() + 20 + m_nameLbl->height() + 18) * 2;
+
+    if (m_user->type() == User::ADDomain && m_user->uid() == 0) {
+        m_passwordEdit->hide();
+        m_otherUserInput->show();
+        frameHeight += m_otherUserInput->height();
+        m_otherUserInput->setFocus();
+    }
+    else if (m_user->type() == User::ADDomain) {
+        m_passwordEdit->show();
+        frameHeight += DDESESSIONCC::PASSWDLINEEDIT_HEIGHT;
+        grabKeyboard();
+    }
+    else {
+        setIsNoPasswordGrp(m_user->isNoPasswdGrp());
+        updateKBLayout(m_user->kbLayoutList());
+        setDefaultKBLayout(m_user->currentKBLayout());
+        frameHeight += DDESESSIONCC::PASSWDLINEEDIT_HEIGHT;
+    }
+
+    setFixedHeight(frameHeight);
 }
 
 void UserInputWidget::onOtherPagePasswordChanged(const QVariant &value)

--- a/session-widgets/userinputwidget.cpp
+++ b/session-widgets/userinputwidget.cpp
@@ -123,6 +123,8 @@ UserInputWidget::UserInputWidget(QWidget *parent)
         FrameDataBind::Instance()->updateValue("Password", value);
     });
     connect(m_passwordEdit, &DPasswdEditAnimated::submit, this, [=] (const QString &passwd) {
+        if (passwd.isEmpty()) return;
+
         emit requestAuthUser(passwd);
     });
     connect(m_loginBtn, &LoginButton::clicked, this, [=] {

--- a/session-widgets/userinputwidget.h
+++ b/session-widgets/userinputwidget.h
@@ -58,6 +58,7 @@ protected:
     bool event(QEvent *event) Q_DECL_OVERRIDE;
     void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
     void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
 
 private:
     void setName(const QString &name);
@@ -66,6 +67,7 @@ private:
     void refreshAvatarPosition();
     void toggleKBLayoutWidget();
     void refreshKBLayoutWidgetPosition();
+    void refreshInputState();
     void onOtherPagePasswordChanged(const QVariant &value);
     void onOtherPageKBLayoutChanged(const QVariant &value);
 


### PR DESCRIPTION
移动用户的nopasswordgrp到函数返回时检查，因为锁屏不再退出了，而无密码登录的设置是立即生效的。

将空密码检查放在userinput那里处理。