### PR TITLE
fix(lock): shutdown fprintd device for the first time

### DIFF
--- a/session-widgets/lockworker.cpp
+++ b/session-widgets/lockworker.cpp
@@ -599,7 +599,8 @@ void LockWorker::lockServiceEvent(quint32 eventType, quint32 pid, const QString 
 
 void LockWorker::onUnlockFinished(bool unlocked)
 {
-    if (isDeepin()) {
+    // only unlock succeed will close fprint device
+    if (unlocked && isDeepin()) {
         m_authFramework->Clear();
     }
 


### PR DESCRIPTION
解锁失败的情况下不能关闭验证过程，否则指纹设备将在第一次认证失败就被关闭。