### PR TITLE
optimize(greeter): forced to draw wallpaper

### DIFF
--- a/lightdm-deepin-greeter/loginwindow.cpp
+++ b/lightdm-deepin-greeter/loginwindow.cpp
@@ -39,10 +39,20 @@ LoginWindow::LoginWindow(SessionBaseModel * const model, QWidget *parent)
 
     connect(m_loginFrame, &LockContent::requestBackground, this, [=] (const QString &wallpaper) {
         updateBackground(wallpaper);
+#ifdef DISABLE_LOGIN_ANI
+        // 在认证成功以后会通过更改背景来实现登录动画，但是禁用登录动画的情况下，会立即调用startSession，
+        // 导致当前进程被lightdm退掉，X上会残留上一帧的画面，可以看到输入框等画面。使用repaint()强制刷新背景来避免这个问题。
+        repaint();
+#endif
     });
 
     connect(model, &SessionBaseModel::authFinished, this, [=] (bool successd) {
         m_loginFrame->setVisible(!successd);
+#ifdef DISABLE_LOGIN_ANI
+        // 在认证成功以后会通过更改背景来实现登录动画，但是禁用登录动画的情况下，会立即调用startSession，
+        // 导致当前进程被lightdm退掉，X上会残留上一帧的画面，可以看到输入框等画面。使用repaint()强制刷新背景来避免这个问题。
+        repaint();
+#endif
     });
 
     connect(m_loginFrame, &LockContent::requestAuthUser, this, &LoginWindow::requestAuthUser);

--- a/session-widgets/lockworker.cpp
+++ b/session-widgets/lockworker.cpp
@@ -798,10 +798,11 @@ void LockWorker::authenticationComplete()
         m_greeter->startSessionSync(m_model->sessionKey());
     };
 
-#ifndef DISABLE_LOGIN_ANI
     // NOTE(kirigaya): It is not necessary to display the login animation.
     emit requestUpdateBackground(m_model->currentUser()->desktopBackgroundPath());
     emit m_model->authFinished(true);
+
+#ifndef DISABLE_LOGIN_ANI
     QTimer::singleShot(1000, this, startSessionSync);
 #else
     startSessionSync();


### PR DESCRIPTION
禁用动画的情况下，控件和壁纸都来不及绘制，lightdm-deepin-greeter就被杀掉了，导致X上残留了一些画面，这个提交会优化这个情况