### PR TITLE
feat: list all inhibitors

### DIFF
--- a/dde-shutdown/view/contentwidget.h
+++ b/dde-shutdown/view/contentwidget.h
@@ -25,10 +25,10 @@
 
 #ifndef CONTENTVIEWWIDGET
 #define CONTENTVIEWWIDGET
-#include <QtWidgets/QFrame>
-#include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QHBoxLayout>
-#include <QtWidgets/QPushButton>
+#include <QFrame>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
 
 #include <memory>
 
@@ -56,9 +56,9 @@ class ContentWidget: public QFrame
 {
     Q_OBJECT
 public:
-    ContentWidget(QWidget* parent=0);
+    ContentWidget(QWidget* parent = nullptr);
     void setModel(SessionBaseModel * const model);
-    ~ContentWidget();
+    ~ContentWidget() override;
 
 signals:
     void requestBackground(const QString &path) const;
@@ -79,7 +79,7 @@ public slots:
     void hideBtns(const QStringList &btnsName);
     void disableBtns(const QStringList &btnsName);
     void onCancel();
-    const QString getInhibitReason();
+    QList<QPair<QString, QString> > listInhibitors();
     void recoveryLayout();
     void runSystemMonitor();
 
@@ -127,7 +127,7 @@ private:
     DBusSessionManagerInterface* m_sessionInterface = nullptr;
     SystemMonitor *m_systemMonitor;
     com::deepin::wm *m_wmInter;
-    Appearance *m_dbusAppearance = NULL;
+    Appearance *m_dbusAppearance = nullptr;
     ImageBlur *m_blurImageInter;
     SessionBaseModel *m_model;
 };

--- a/dde-shutdown/view/inhibitwarnview.h
+++ b/dde-shutdown/view/inhibitwarnview.h
@@ -32,15 +32,25 @@
 
 #include <QWidget>
 
+class InhibitorRow : public QWidget
+{
+    Q_OBJECT
+public:
+    InhibitorRow(QString who, QString why);
+    InhibitorRow(const QPair<QString, QString> data) : InhibitorRow(data.first, data.second) {}
+    ~InhibitorRow() override;
+};
+
 class InhibitWarnView : public WarningView
 {
     Q_OBJECT
 
 public:
-    explicit InhibitWarnView(QWidget *parent = 0);
-    ~InhibitWarnView();
+    explicit InhibitWarnView(QWidget *parent = nullptr);
+    ~InhibitWarnView() override;
 
-    void setInhibitReason(const QString &reason);
+    void setInhibitorList(const QList<QPair<QString, QString> > & list);
+    void setInhibitConfirmMessage(const QString &text);
     void setAcceptReason(const QString &reason) override;
     void setAction(const Actions action);
     void setAcceptVisible(const bool acceptable);
@@ -58,7 +68,9 @@ private:
 private:
     Actions m_action;
 
-    QLabel *m_reasonLbl;
+    QList<QWidget*> m_inhibitorPtrList;
+    QVBoxLayout *m_inhibitorListLayout = nullptr;
+    QLabel *m_confirmTextLabel = nullptr;
     RoundItemButton *m_acceptBtn;
     RoundItemButton *m_cancelBtn;
     RoundItemButton *m_currentBtn;


### PR DESCRIPTION
PMS taskID=6259

之前检查应用商店的地方改成了检查所有试图阻止关机的应用，并列表显示这些应用。

![image](https://user-images.githubusercontent.com/10095765/61278707-3f223080-a7e7-11e9-8285-6984296713f6.png)

和新设计有一些冲突所以这个提交没严格按照设计图来做。冲突的地方是：

1. 没有关机按钮，只能取消。
2. 只显示所有试图阻止（block）关机的项，没有显示允许延缓的项。
3. 无法获得阻止关机的应用程序的图标。

1 的原因是之前只检查商店的情况就没有，并且 block 关机的情况就是要阻止关机。2 是这次提交只打算支持 block 阻止关机，如果确定要支持 delay 的话可以细分到别的提交来做。另外是，如果 delay 的话，是要发送  `PrepareForShutdown()` / `PrepareForSleep()` dbus 信号用来通知程序的（比如程序收到信号后做保存文件之类的行为），这个信号由谁来发我还没仔细研究。3 是因为 `Inhibit()` 只提供了应用名称和应用阻止关机行为的原因这两个参数（另外两个参数是阻止模式 block/delay 和阻止什么行为 shutdown/logout/etc）。