### PR TITLE
Correction that setxkbmap now also considers the variation of the keyboard layout.

### DIFF
--- a/widgets/kblayoutwidget.cpp
+++ b/widgets/kblayoutwidget.cpp
@@ -165,7 +165,15 @@ void KbLayoutWidget::setButtonsChecked(QString text) {
         }
     }
 
-    proc->start("setxkbmap", QStringList() << "-model" << model << "-layout" << kbd.split(";").first());
+    qDebug() << "Working on layout string:" << kbd;  
+    QStringList layout = kbd.split(";");
+    QStringList xkb_command;
+    xkb_command << "-model" << model << "-layout" << layout.first();
+
+    if(layout.length() > 1)
+        xkb_command << "-variant" << layout.at(1);
+
+    proc->start("setxkbmap", xkb_command);
     proc->waitForFinished();
     qDebug() << proc->exitCode() << proc->readAll() << proc->program() << proc->arguments();
 


### PR DESCRIPTION
There is an issue about this pull request in this project and in the internal discussions.
Issue: https://github.com/linuxdeepin/dde-session-ui/issues/36
Discussion: https://github.com/linuxdeepin/internal-discussion/issues/1992

It's relatively simple. The command to restore the keyboard layout after locking, suspension or hibernation `setxkbmap` breaks the layout if a variation is used and the flag `-variant` is missing. I have already tested the added code with `us;intl` or English (US, international with dead keys) . For further variations it should work the same.