### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,19 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-session-ui.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-session-ui.spec
+    - .packit.yaml
+
+upstream_package_name: dde-session-ui
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-session-ui
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-session-ui.spec"
+  post-upstream-clone: |
+    cp rpm/dde-session-ui.spec rpm/deepin-session-ui.spec

--- a/rpm/dde-session-ui.spec
+++ b/rpm/dde-session-ui.spec
@@ -1,15 +1,23 @@
-Name:           dde-session-ui
-Version:        5.1.0.11
-Release:        2
+%global repo dde-session-ui
+%global __provides_exclude_from ^%{_libdir}/dde-dock/.*\\.so$
+
+%if 0%{?fedora}
+Name:           deepin-session-ui
+%else
+Name:           %{repo}
+%endif
+Version:        5.3.0.22
+Release:        1%{?fedora:%dist}
 Summary:        Deepin desktop-environment - Session UI module
 License:        GPLv3
-URL:            https://github.com/linuxdeepin/%{name}
-Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+URL:            https://github.com/linuxdeepin/%{repo}
+Source0:        %{url}/archive/%{version}/%{repo}-%{version}.tar.gz
 
 BuildRequires:  gcc-c++
 BuildRequires:  deepin-gettext-tools
 BuildRequires:  pkgconfig(dtkwidget) >= 5.1
 BuildRequires:  pkgconfig(dframeworkdbus)
+BuildRequires:  pkgconfig(dde-dock)
 BuildRequires:  pkgconfig(gsettings-qt)
 BuildRequires:  pkgconfig(gtk+-2.0)
 BuildRequires:  pkgconfig(libsystemd)
@@ -18,18 +26,22 @@ BuildRequires:  pkgconfig(xcursor)
 BuildRequires:  pkgconfig(xtst)
 BuildRequires:  pkgconfig(xext)
 BuildRequires:  golang-github-msteinert-pam-devel
-BuildRequires:  qt5-devel
 BuildRequires:  dtkcore-devel >= 5.1
-BuildRequires:  dde-dock-devel
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(Qt5Xml)
+BuildRequires:  pkgconfig(Qt5X11Extras)
+BuildRequires:  pkgconfig(Qt5Multimedia)
+%if 0%{?fedora}
+Requires:       deepin-daemon
+%else
 Requires:       dde-daemon
+%endif
 Requires:       startdde
 
-Requires:       lightdm
-Requires(post): sed
-Provides:       lightdm-deepin-greeter = %{version}-%{release}
-Provides:       lightdm-greeter = 1.2
 Provides:       deepin-notifications = %{version}-%{release}
-Obsoletes:      deepin-notifications < %{version}-%{release}
+Obsoletes:      deepin-notifications <= 3.3.4
 
 %description
 This project include those sub-project:
@@ -44,8 +56,7 @@ This project include those sub-project:
 - dde-hotzone: User interface of setting hot zone.
 
 %prep
-%setup -q -n %{name}-%{version}
-sed -i 's|default_background.jpg|default.png|' widgets/fullscreenbackground.cpp
+%autosetup -p1 -n %{repo}-%{version}
 sed -i 's|lib|libexec|' \
     misc/applications/deepin-toggle-desktop.desktop* \
     dde-osd/dde-osd_autostart.desktop \
@@ -62,7 +73,7 @@ sed -i 's|lib|libexec|' \
     dde-suspend-dialog/dde-suspend-dialog.pro \
     dnetwork-secret-dialog/dnetwork-secret-dialog.pro \
     dde-lowpower/dde-lowpower.pro
-sed -i 's|/usr/lib/dde-dock|/usr/lib64/dde-dock|' dde-notification-plugin/notifications/notifications.pro
+sed -i 's|/usr/lib/dde-dock|%{_libdir}/dde-dock|' dde-notification-plugin/notifications/notifications.pro
 
 %build
 export PATH=%{_qt5_bindir}:$PATH
@@ -72,16 +83,13 @@ export PATH=%{_qt5_bindir}:$PATH
 %install
 %make_install INSTALL_ROOT=%{buildroot}
 
-%post
-sed -i "s|#greeter-session.*|greeter-session=lightdm-deepin-greeter|g" /etc/lightdm/lightdm.conf
-
 %files
 %doc README.md
 %license LICENSE
 %{_bindir}/dde-*
 %{_bindir}/dmemory-warning-dialog
 %{_libexecdir}/deepin-daemon/*
-%{_datadir}/%{name}/
+%{_datadir}/%{repo}/
 %{_datadir}/icons/hicolor/*/apps/*
 %{_datadir}/dbus-1/services/*.service
 %{_libdir}/dde-dock/plugins/libnotifications.so


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>