### PR TITLE
fix: install prefix not effective

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -27,11 +27,11 @@ prepare() {
 
 build() {
   cd $deepin_source_name
-  cmake -B build -GNinja -DCMAKE_INSTALL_PREFIX=/usr
+  cmake -B build -GNinja -DCMAKE_INSTALL_PREFIX=$pkgdir/usr
   cmake --build build
 }
 
 package() {
   cd $deepin_source_name
-  cmake --install build --prefix "$pkgdir"
+  cmake --install build
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-dde-session-ui (3.0.14-1) unstable; urgency=low
+dde-session-ui (3.0.14) unstable; urgency=low
 
   * Autobuild Tag 3.0.14 
 


### PR DESCRIPTION
cmake --install . --prefix will override -DCMAKE_INSTALL_PREFIX


<img width="1397" alt="image" src="https://user-images.githubusercontent.com/12298476/181670054-11391328-557c-4b0a-b959-365b10ac2786.png">
