### PR TITLE
chore: build on newer debian release

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends},
  dbus-x11,
  dde-session-shell,
  pandoc,
- libxcb-util0
+ libxcb-util0 | libxcb-util1
 Provides: lightdm-greeter
 Recommends: onboard
 Conflicts: dde-workspace,


### PR DESCRIPTION
更新依赖描述（libxcb-util0 -> libxcb-util1），使可以在新版 debian 中顺利构建。（注：在 v20 停止支持后，可考虑移除 libxcb-util0 依赖）

是处理 linuxdeepin/developer-center#3230 问题的一部分。

Log: build on new debian release
Influence: build
Change-Id: Ie9ef716c2190fed9f2583fcc84553534113b45ad