### PR TITLE
fix: 锁屏时通知窗口获得焦点，打断当前焦点输入

### DIFF
--- a/dde-osd/notification/bubble.cpp
+++ b/dde-osd/notification/bubble.cpp
@@ -240,7 +240,7 @@ void Bubble::initUI()
 
     setAttribute(Qt::WA_TranslucentBackground);
     setAttribute(Qt::WA_DeleteOnClose);
-    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Tool | Qt::X11BypassWindowManagerHint);
+    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::Tool | Qt::X11BypassWindowManagerHint | Qt::WindowDoesNotAcceptFocus);
     setBlendMode(DBlurEffectWidget::BehindWindowBlend);
     setMaskColor(DBlurEffectWidget::AutoColor);
     setMouseTracking(true);


### PR DESCRIPTION
添加WindowDoesNotAcceptFocus窗口属性

Log: 锁屏时通知窗口获得焦点，打断当前焦点输入
Bug: https://pms.uniontech.com/bug-view-155551.html
Influence: 锁屏时弹出通知窗口，不会触发焦点切换，不会影响当前正在进行的业务流程
Change-Id: Idda0bc0fecedb10235cde3494a8b4facdb59a6f8