### PR TITLE
fix: wayland下锁屏不显示OSD

### DIFF
--- a/dde-osd/container.cpp
+++ b/dde-osd/container.cpp
@@ -56,7 +56,8 @@ Container::Container(QWidget *parent)
 
     if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {
         setAttribute(Qt::WA_NativeWindow);
-        windowHandle()->setProperty("_d_dwayland_window-type", "tooltip");
+        // 慎重修改层级，特别考虑对锁屏的影响
+        windowHandle()->setProperty("_d_dwayland_window-type", "onScreenDisplay");
     }
 
     m_quitTimer->setSingleShot(true);


### PR DESCRIPTION
原因:锁屏层级为onScreenDisplay,osd的层级为tooltip
解决方案: osd提示的层级提高到onScreenDisplay

Log: 修复wayland下锁屏不显示OSD提示的问题
Bug: https://pms.uniontech.com/bug-view-155345.html
Influence: wayland锁屏OSD弹窗
Change-Id: I9136a8bd321b8986c3c31a49dc5f673efe320213