### PR TITLE
fix: 修改dde-osd程序启动方式

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ install(TARGETS ${OSD_Name} DESTINATION lib/deepin-daemon)
 ## service
 file(GLOB OSD_SERVICE_FILES "dde-osd/files/*.service")
 install(FILES ${OSD_SERVICE_FILES} DESTINATION share/dbus-1/services)
+install(FILES dde-osd/files/dde-osd.desktop DESTINATION share/applications/)
 
 #-----------------------------ut-dde-osd-----------------------------
 #--todo: 单元测试编译不通过，需修改后取消注释

--- a/dde-osd/files/com.deepin.dde.Notification.service
+++ b/dde-osd/files/com.deepin.dde.Notification.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.Notification
-Exec=/usr/lib/deepin-daemon/dde-osd
+Exec=/usr/bin/qdbus --literal com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch /usr/share/applications/dde-osd.desktop

--- a/dde-osd/files/com.deepin.dde.freedesktop.Notification.service
+++ b/dde-osd/files/com.deepin.dde.freedesktop.Notification.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.freedesktop.Notifications
-Exec=/usr/lib/deepin-daemon/dde-osd
+Exec=/usr/bin/qdbus --literal com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch /usr/share/applications/dde-osd.desktop

--- a/dde-osd/files/com.deepin.dde.osd.service
+++ b/dde-osd/files/com.deepin.dde.osd.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.osd
-Exec=/usr/lib/deepin-daemon/dde-osd
+Exec=/usr/bin/qdbus --literal com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch /usr/share/applications/dde-osd.desktop

--- a/dde-osd/files/dde-osd.desktop
+++ b/dde-osd/files/dde-osd.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Deepin OSD
+Comment=Deepin OSD
+Exec=/usr/lib/deepin-daemon/dde-osd
+NoDisplay=true
+OnlyShowIn=Deepin
+Type=Application
+X-Deepin-Vendor=user-custom
+X-Deepin-TurboType=dtkwidget


### PR DESCRIPTION
根因:systemd方式启动的进程没有正确获取环境变量，界面透明效果异常
修复:修改dde-osd程序启动方式，通过StartManager.Launch启动desktop文件方式启动进程，以继承环境变量

Log: 修复通知中心的毛玻璃蒙层效果丢失的问题
Bug: https://pms.uniontech.com/bug-view-155485.html
Influence: 正常显示界面效果