### PR TITLE
fix: 修复部分情况下osd不显示的问题

### DIFF
--- a/dde-osd/container.cpp
+++ b/dde-osd/container.cpp
@@ -30,7 +30,7 @@ Container::Container(QWidget *parent)
     , m_supportComposite(m_wmHelper->hasComposite())
 {
     setAccessibleName("Container");
-    setWindowFlags(Qt::ToolTip | Qt::WindowTransparentForInput | Qt::WindowDoesNotAcceptFocus);
+    setWindowFlags(Qt::Tool | Qt::WindowTransparentForInput | Qt::WindowDoesNotAcceptFocus);
     setAttribute(Qt::WA_TranslucentBackground);
 
     if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {


### PR DESCRIPTION
osd窗口属性由Qt::ToolTip改为Tool，ToolTip一般用于QToolTip的实现，
工具型的窗口应该用Qt::Tool，且在使用ToolTip时，会导致此问题

Log: 修复部分情况下osd不显示的问题
Influence: 通知消失的时候弹出osd会不显示(需要频繁按出osd)
Bug: https://pms.uniontech.com/bug-view-156715.html
Change-Id: If70a28b5c756d7d98d59cb399c395b723104d494