### PR TITLE
fix: 修复蓝牙连接PIN码问题

### DIFF
--- a/dde-bluetooth-dialog/main.cpp
+++ b/dde-bluetooth-dialog/main.cpp
@@ -19,6 +19,7 @@ DCORE_USE_NAMESPACE
 const int PingCode = 1;
 const int DevicePath = 2;
 const int PingTime = 3;
+const int CancelBtnState = 4;
 
 int main(int argc, char *argv[])
 {
@@ -30,13 +31,14 @@ int main(int argc, char *argv[])
     app.installTranslator(&translator);
 
     QStringList arguslist = app.arguments();
-    if (arguslist.size() < 4) {
-        qDebug() << "number of parameters must be greater than 3";
+    if (arguslist.size() < 5) {
+        qDebug() << "number of parameters must be greater than 4";
         return -1;
     }
-    qDebug() << "PingCode:" << arguslist[PingCode] << " Device Path:" << arguslist[DevicePath] << "Ping Time:" + arguslist[PingTime];
+    qDebug() << "PingCode:" << arguslist[PingCode] << " Device Path:" << arguslist[DevicePath] << "Ping Time:" + arguslist[PingTime]
+             << "isCancelBtnShown:" << arguslist[CancelBtnState].toInt();
 
-    PinCodeDialog dialog(arguslist[PingCode], arguslist[DevicePath], arguslist[PingTime], true);
+    PinCodeDialog dialog(arguslist[PingCode], arguslist[DevicePath], arguslist[PingTime], arguslist[CancelBtnState].toInt());
 #if (defined QT_DEBUG) && (defined CHECK_ACCESSIBLENAME)
     AccessibilityCheckerEx checker;
     checker.setOutputFormat(DAccessibilityChecker::FullFormat);


### PR DESCRIPTION
新增命令行启动第4个参数,控制取消按钮的显示隐藏

Log:
Bug: https://pms.uniontech.com/bug-view-155417.html
Influence: 控制中心、任务栏蓝牙连接可以弹PIN码的设备时统一弹dde-session-ui/dde-bluetooth-dialog对话框