### PR TITLE
fix: 低电量界面和锁屏交互异常

### DIFF
--- a/dde-lowpower/window.cpp
+++ b/dde-lowpower/window.cpp
@@ -25,6 +25,11 @@ Window::Window(QWidget *parent)
     m_text->setAccessibleName("LowPowerText");
     // set window flags as dde-lock, so we can easily cover it.
     setWindowFlags(Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
+    if (QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive)) {
+        setAttribute(Qt::WA_NativeWindow);
+        // 慎重修改层级，特别考虑对锁屏的影响
+        windowHandle()->setProperty("_d_dwayland_window-type", "override");
+    }
 
     const qreal ratio = devicePixelRatioF();
     const QString iconPath = qt_findAtNxFile(":/images/lowpower.png", ratio);


### PR DESCRIPTION
低电量待机后唤醒，显示的是锁屏而不是低电量提醒界面，原因是低电量提示界面层级笔锁屏要低，需要将层级提高为override

Log: 修复低电量界面和锁屏交互异常的问题
Bug: https://pms.uniontech.com/bug-view-157769.html
Influence: 低电量提醒
Change-Id: I85df852092173a0f85d6d53253265166fdb8df0b