### PR TITLE
fix: 修复A用户启用或禁用触摸板,进入B用户登录页面,会自动弹出osd弹窗问题

### DIFF
--- a/dde-osd/manager.cpp
+++ b/dde-osd/manager.cpp
@@ -57,6 +57,16 @@ void Manager::ShowOSD(const QString &osd)
 {
     qDebug() << "show osd" << osd;
 
+    QDBusInterface inter("org.freedesktop.login1",
+                         "/org/freedesktop/login1/session/self",
+                         "org.freedesktop.login1.Session",
+                         QDBusConnection::systemBus());
+    if(!inter.property("Active").toBool())
+    {
+        qWarning() << "self session is not active";
+        return;
+    }
+
     // 3D WM need long time, OSD will disappear too fast
     m_timer->setInterval(osd == "SwitchWM3D" ? 2000 : 1000);
 


### PR DESCRIPTION
非激活session下的osd会对请求进行响应
判断session是否激活,非激活不响应

Log: 对osd请求进行优化
Bug: https://pms.uniontech.com/bug-view-153133.html
Influence: osd弹框