### PR TITLE
fix: 修正蓝牙弹窗参数个数的校正和入参处理

### DIFF
--- a/dde-bluetooth-dialog/main.cpp
+++ b/dde-bluetooth-dialog/main.cpp
@@ -31,14 +31,17 @@ int main(int argc, char *argv[])
     app.installTranslator(&translator);
 
     QStringList arguslist = app.arguments();
-    if (arguslist.size() < 5) {
-        qDebug() << "number of parameters must be greater than 4";
+    if (arguslist.size() < 4) {
+        qDebug() << "number of parameters must be greater than 3";
         return -1;
     }
+    auto cancelable = true;
+    if (arguslist.size() >= 5) {
+        cancelable = arguslist[CancelBtnState] == "true";
+    }
     qDebug() << "PingCode:" << arguslist[PingCode] << " Device Path:" << arguslist[DevicePath] << "Ping Time:" + arguslist[PingTime]
-             << "isCancelBtnShown:" << arguslist[CancelBtnState].toInt();
-
-    PinCodeDialog dialog(arguslist[PingCode], arguslist[DevicePath], arguslist[PingTime], arguslist[CancelBtnState].toInt());
+             << "isCancelBtnShown:" << cancelable;
+    PinCodeDialog dialog(arguslist[PingCode], arguslist[DevicePath], arguslist[PingTime], cancelable);
 #if (defined QT_DEBUG) && (defined CHECK_ACCESSIBLENAME)
     AccessibilityCheckerEx checker;
     checker.setOutputFormat(DAccessibilityChecker::FullFormat);


### PR DESCRIPTION
1.蓝牙弹窗参数可以为3个，保证兼容旧版本dde-daemon;
2.第四个参数为"true"或"false"的字符串;

Log: 修正蓝牙弹窗参数个数的校正和入参处理
Bug: https://pms.uniontech.com/bug-view-160137.html
Influence: 蓝牙连接
Change-Id: I501f903afaf0c10894304888da57ccb904841e82