### PR TITLE
chore: modify README license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ We encourage you to report issues and contribute changes
 * [开发者代码贡献指南](https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers) (中文)
 
 ## License
-GNU General Public License, Version 3.0
+DDE session ui is licensed under [GPL-3.0-or-later](LICENSE).

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -68,4 +68,4 @@
 * [开发者代码贡献指南](https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers) (中文)
 
 ## License
-GNU General Public License, Version 3.0
+dde-session-ui 在 [GPL-3.0-or-later](LICENSE) 下发布。


### PR DESCRIPTION
The protocol name in the README is written according to the standard specification

Log: modify README license information
Influence: none
Task: https://pms.uniontech.com/task-view-185215.html
Change-Id: Ief84871581f57509f55b43b87c56e943d9211e68