### PR TITLE
fix: 显示不同类型OSD时需要重新调整界面大小

### DIFF
--- a/dde-osd/manager.cpp
+++ b/dde-osd/manager.cpp
@@ -101,9 +101,11 @@ void Manager::ShowOSD(const QString &osd)
     }
 
     if (m_currentProvider) {
-        if (!m_currentProvider->checkConditions() && m_container->isVisible()) {
+        // 在显示下一个不同类型的OSD前先隐藏前面显示的界面，避免界面不会调整大小
+        if ((!m_currentProvider->checkConditions() && m_container->isVisible()) || !repeat) {
             m_container->hide();
         }
+
         updateUI();
         if (repeat && m_container->isVisible()) {
             KBLayoutProvider *provide = qobject_cast<KBLayoutProvider *>(m_currentProvider);


### PR DESCRIPTION
上一个OSD没有隐藏时，显示下一个OSD时没有调整界面大小，会使用上一个界面的尺寸，造成界面显示不全

Log: 修复F1-F9热键，第二个OSD窗口会记录第一个OSD窗口大小的问题
Bug: https://pms.uniontech.com/bug-view-161429.html
Influence: 使用F1-F9功能按键时正常显示OSD