### PR TITLE
fix: 社区版登录桌面时版本提示信息错误

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -35,8 +35,8 @@ License: CC0-1.0
 
 # sh
 Files: lupdate.sh tests/test-recoverage.sh translate_generation.sh 
-Copyright: None
-License: CC0-1.0
+Copyright: UnionTech Software Technology Co., Ltd.
+License: GPL-3.0-or-later
 
 # qss
 Files: src/*.qss
@@ -60,6 +60,11 @@ License: CC0-1.0
 
 # qss service
 Files: dde-osd/light.qss dde-osd/files/*.service dde-warning-dialog/*.service dde-welcome/*.service dmemory-warning-dialog/*.service
+Copyright: UnionTech Software Technology Co., Ltd.
+License: GPL-3.0-or-later
+
+# desktop
+Files: dde-osd/files/dde-osd.desktop
 Copyright: UnionTech Software Technology Co., Ltd.
 License: GPL-3.0-or-later
 

--- a/dde-welcome/utils.cpp
+++ b/dde-welcome/utils.cpp
@@ -6,15 +6,15 @@
 
 const std::pair<QString, QString> GetSystemVersion()
 {
-    QSettings lsbSetting("/etc/deepin-version", QSettings::IniFormat);
+    QSettings lsbSetting("/etc/os-version", QSettings::IniFormat);
     lsbSetting.setIniCodec("utf-8");
-    lsbSetting.beginGroup("Release");
+    lsbSetting.beginGroup("Version");
     QLocale locale;
 
     if (locale.language() == QLocale::Chinese)
-        return std::pair<QString, QString>{ lsbSetting.value("Version").toString(),
-                    lsbSetting.value(QString("Type[%1]").arg(locale.name()), "").toString() };
+        return std::pair<QString, QString>{ lsbSetting.value("MinorVersion").toString(),
+                    lsbSetting.value(QString("EditionName[%1]").arg(locale.name()), "").toString() };
 
-    return std::pair<QString, QString>{ lsbSetting.value("Version").toString(),
-                lsbSetting.value(QString("Type"), "").toString() };
+    return std::pair<QString, QString>{ lsbSetting.value("MinorVersion").toString(),
+                lsbSetting.value(QString("EditionName"), "").toString() };
 }


### PR DESCRIPTION
根据os-version去读取对应的版本信息，防止显示的版本信息错误

Log: 修复社区版登录桌面时版本提示信息错误的问题
Bug: https://pms.uniontech.com/bug-view-137439.html
Influence: 登录界面版本提示信息
Change-Id: I8338e51a0cc2706507c59270a048a9f447ac34af