### PR TITLE
fix: 修复待机休眠后osd无法显示问题

### DIFF
--- a/dde-osd/files/com.deepin.dde.Notification.service
+++ b/dde-osd/files/com.deepin.dde.Notification.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.Notification
-Exec=/usr/bin/qdbus --literal com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch /usr/share/applications/dde-osd.desktop
+Exec=/usr/bin/dbus-send --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch string:"/usr/share/applications/dde-osd.desktop"

--- a/dde-osd/files/com.deepin.dde.freedesktop.Notification.service
+++ b/dde-osd/files/com.deepin.dde.freedesktop.Notification.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.freedesktop.Notifications
-Exec=/usr/bin/qdbus --literal com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch /usr/share/applications/dde-osd.desktop
+Exec=/usr/bin/dbus-send --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch string:"/usr/share/applications/dde-osd.desktop"

--- a/dde-osd/files/com.deepin.dde.osd.service
+++ b/dde-osd/files/com.deepin.dde.osd.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.dde.osd
-Exec=/usr/bin/qdbus --literal com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch /usr/share/applications/dde-osd.desktop
+Exec=/usr/bin/dbus-send --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.Launch string:"/usr/share/applications/dde-osd.desktop"


### PR DESCRIPTION
由于社区缺少qdbus工具，改用dbus-send命令

Log: 修复待机休眠后osd无法显示问题
Bug: https://pms.uniontech.com/bug-view-161737.html
Influence: osd显示
Change-Id: I7812edcb647742ef7152baf211a57daa5cb426d1