### PR TITLE
fix: 修复通知中心鼠标点击或滚轮滚动都会导致隐藏的问题

### DIFF
--- a/dde-osd/notification-center/notifycenterwidget.cpp
+++ b/dde-osd/notification-center/notifycenterwidget.cpp
@@ -277,10 +277,19 @@ void NotifyCenterWidget::registerRegion()
     if (interface.isValid()) {
         m_regionConnect = connect(m_regionMonitor, &DRegionMonitor::buttonRelease, this, [ = ](const QPoint & p) {
             QPoint pScale(int(qreal(p.x() / m_scale)), int(qreal(p.y() / m_scale)));
-            if (!geometry().contains(pScale))
-                if (!isHidden()) {
-                    hideAni();
-                }
+            // 多屏开缩放下，qt坐标有问题，需要手动计算
+            QScreen *screen = windowHandle()->screen();
+            if (screen) {
+                const QRect screenRect = screen->geometry();
+                QRect rect = geometry();
+                rect.setX(screenRect.x() / m_scale + geometry().x() - screenRect.x());
+                if (!rect.contains(pScale))
+                    if (!isHidden()) {
+                        hideAni();
+                    }
+            } else {
+                qWarning() << "windowHandle()->screen() is null";
+            }
         });
     }
 


### PR DESCRIPTION
多屏开缩放的情况下，qt获取的坐标有问题，需要重新计算

Log: 修复通知中心鼠标点击或滚轮滚动都会导致隐藏的问题
Bug: https://pms.uniontech.com/bug-view-163961.html
Influence: 通知中心
Change-Id: I2022d112191b9f878d7f9192b29b28f547ead853