### PR TITLE
fix: 需要根据X11或wayland分别设置窗口属性

### DIFF
--- a/dde-osd/container.cpp
+++ b/dde-osd/container.cpp
@@ -30,13 +30,15 @@ Container::Container(QWidget *parent)
     , m_supportComposite(m_wmHelper->hasComposite())
 {
     setAccessibleName("Container");
-    setWindowFlags(Qt::Tool | Qt::WindowTransparentForInput | Qt::WindowDoesNotAcceptFocus);
     setAttribute(Qt::WA_TranslucentBackground);
 
     if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {
+        setWindowFlags(Qt::Tool | Qt::WindowTransparentForInput | Qt::WindowDoesNotAcceptFocus);
         setAttribute(Qt::WA_NativeWindow);
         // 慎重修改层级，特别考虑对锁屏的影响
         windowHandle()->setProperty("_d_dwayland_window-type", "onScreenDisplay");
+    } else {
+        setWindowFlags(Qt::ToolTip | Qt::WindowTransparentForInput | Qt::WindowDoesNotAcceptFocus);
     }
 
     m_quitTimer->setSingleShot(true);


### PR DESCRIPTION
需要根据X11或wayland分别设置窗口属性

Log: 修复在字体字号设置为20后，窗口特效开关OSD提示界面显示不完整的问题
Bug: https://pms.uniontech.com/bug-view-164657.html
Influence: 窗口特效开关OSD提示界面正常显示