### PR TITLE
chore: 修复dde-osd的GetRecordsFromId接口调用失败问题

### DIFF
--- a/dde-osd/notification/persistence.cpp
+++ b/dde-osd/notification/persistence.cpp
@@ -344,6 +344,7 @@ QString Persistence::getFrom(int rowCount, const QString &offsetId)
     sqlCmd += TableName_v2;
     sqlCmd += QString(" LIMIT (:rowCount) OFFSET (:offset)");
 
+    m_query.prepare(sqlCmd);
     m_query.bindValue(":rowCount", rowCount);
     m_query.bindValue(":offset", rowNum);
 


### PR DESCRIPTION
原因：sqlcmd未prepare，未执行数据库查询，接口返回错误
修改：添加 m_query.prepare(sqlCmd)

Log: 修复dde-osd的GetRecordsFromId接口调用失败问题
Influence: GetRecordsFromId接口