### PR TITLE
chore: 修复dde-osd的GetCapabilities接口调用失败的问题

### DIFF
--- a/dde-osd/notification/notifications_dbus_adaptor.cpp
+++ b/dde-osd/notification/notifications_dbus_adaptor.cpp
@@ -136,11 +136,11 @@ QStringList DDENotifyDBus::GetAppList()
     return out0;
 }
 
-QStringList DDENotifyDBus::GetCapbilities()
+QStringList DDENotifyDBus::GetCapabilities()
 {
     // handle method call com.deepin.dde.Notification.GetCapbilities
     QStringList out0;
-    QMetaObject::invokeMethod(parent(), "GetCapbilities", Q_RETURN_ARG(QStringList, out0));
+    QMetaObject::invokeMethod(parent(), "GetCapabilities", Q_RETURN_ARG(QStringList, out0));
     return out0;
 }
 

--- a/dde-osd/notification/notifications_dbus_adaptor.h
+++ b/dde-osd/notification/notifications_dbus_adaptor.h
@@ -66,7 +66,7 @@ class DDENotifyDBus: public QDBusAbstractAdaptor
 "    <method name=\"CloseNotification\">\n"
 "      <arg direction=\"in\" type=\"u\"/>\n"
 "    </method>\n"
-"    <method name=\"GetCapbilities\">\n"
+"    <method name=\"GetCapabilities\">\n"
 "      <arg direction=\"out\" type=\"as\"/>\n"
 "    </method>\n"
 "    <method name=\"GetServerInformation\">\n"
@@ -198,7 +198,7 @@ public Q_SLOTS: // METHODS
     QString GetAllRecords();
     QDBusVariant GetAppInfo(const QString &in0, uint in1);
     QStringList GetAppList();
-    QStringList GetCapbilities();
+    QStringList GetCapabilities();
     QString GetRecordById(const QString &in0);
     QString GetRecordsFromId(int in0, const QString &in1);
     QString GetServerInformation(QString &out1, QString &out2, QString &out3);


### PR DESCRIPTION
接口名称未对应，GetCapbilities书写错误, dbus调用失败

Log: 修复dde-osd的GetCapabilities接口调用失败的问题
Influence: dde-osd的GetCapabilities