### PR TITLE
fix: 根据UI设计要求调整标题间距

### DIFF
--- a/dde-osd/notification-center/itemdelegate.cpp
+++ b/dde-osd/notification-center/itemdelegate.cpp
@@ -63,7 +63,13 @@ void ItemDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewI
 {
     Q_UNUSED(index)
 
+    EntityPtr notify = index.data().value<EntityPtr>();
+
     QRect rect = option.rect;
     QSize size = sizeHint(option, index);
-    editor->setGeometry(rect.x(), rect.y(), size.width(), size.height() - BubbleSpacing);
+    // 应用标题到消息通知间距为6
+    if (notify && notify->isTitle())
+        editor->setGeometry(rect.x(), rect.y(), size.width(), size.height() - 6);
+    else
+        editor->setGeometry(rect.x(), rect.y(), size.width(), size.height() - BubbleSpacing);
 }

--- a/dde-osd/notification-center/notifycenterwidget.cpp
+++ b/dde-osd/notification-center/notifycenterwidget.cpp
@@ -97,6 +97,7 @@ void NotifyCenterWidget::initUI()
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->setContentsMargins(Notify::CenterMargin, Notify::CenterMargin, 0, 0);
     mainLayout->addWidget(m_headWidget);
+    mainLayout->addSpacing(20);
     mainLayout->addWidget(m_notifyWidget);
 
     setLayout(mainLayout);


### PR DESCRIPTION
根据UI设计要求，调整消息通知主标题和消息通知列表间距为20,调整消息通知应用标题和消息通知内容间距为6

Log: 修复标题与内容间距问题
Bug: https://pms.uniontech.com/bug-view-167541.html
Influence: 标题与内容间距按要求显示