### PR TITLE
fix: 修改消息中心清除按钮焦点策略和状态颜色

### DIFF
--- a/dde-osd/notification-center/notifycenterwidget.cpp
+++ b/dde-osd/notification-center/notifycenterwidget.cpp
@@ -83,7 +83,7 @@ void NotifyCenterWidget::initUI()
     m_clearButton->setOpacity(IconButton::RELEASE, 255 * 0.0);
     m_clearButton->setRadius(Notify::CenterTitleHeight / 2);
     m_clearButton->setFixedSize(Notify::CenterTitleHeight, Notify::CenterTitleHeight);
-    m_clearButton->setFocusPolicy(Qt::StrongFocus);
+    m_clearButton->setFocusPolicy(Qt::ClickFocus);
 
     QHBoxLayout *head_Layout = new QHBoxLayout;
     head_Layout->addWidget(bell_notify, Qt::AlignLeft | Qt::AlignTop);

--- a/dde-osd/notification/iconbutton.cpp
+++ b/dde-osd/notification/iconbutton.cpp
@@ -62,13 +62,13 @@ void IconButton::paintEvent(QPaintEvent *event)
         color = QColor("#FFFFFF");
     }
 
-    switch (m_currentState) {
-    case HOVER: color.setAlpha(m_hoverOpacity); break;
-    case PRESS: color.setAlpha(m_pressOpacity); break;
-    case RELEASE: color.setAlpha(m_releaseOpacity); break;
+    if (m_currentState == PRESS) {
+        color.setAlpha(m_pressOpacity);
+    } else if (m_currentState == HOVER || hasFocus()) {
+        color.setAlpha(m_hoverOpacity);
+    } else {
+        color.setAlpha(m_releaseOpacity);
     }
-
-    color.setAlpha(hasFocus() ? m_hoverOpacity : color.alpha());
 
     painter.setPen(Qt::NoPen);
     painter.setBrush(color);
@@ -146,6 +146,8 @@ void IconButton::leaveEvent(QEvent *event)
 {
     Q_UNUSED(event);
     m_currentState = RELEASE;
+    // 鼠标离开时需要清除焦点，不然会一直显示 hover状态
+    clearFocus();
     update();
 
     return DWidget::leaveEvent(event);


### PR DESCRIPTION
1、在鼠标离开按钮时需要清除焦点，否则会一直显示 hover状态颜色
2、修改按钮焦点策略，否则启动时就会获得焦点显示 hover状态颜
3、判断状态条件不对，无法区分点击和悬浮状态，会一直显示 hover状态颜色

Log: 修复消息中心清除按钮交互问题
Bug: https://pms.uniontech.com/bug-view-167501.html
Influence: 清除按钮正常显示交互颜色