### PR TITLE
fix: 消息通知标题和内容间隔4像素

### DIFF
--- a/dde-osd/notification/appbody.cpp
+++ b/dde-osd/notification/appbody.cpp
@@ -26,6 +26,7 @@ AppBody::AppBody(QWidget *parent)
     layout->setSpacing(0);
     layout->addStretch();
     layout->addWidget(m_titleLbl, 0, Qt::AlignVCenter);
+    layout->addSpacing(4);
     layout->addWidget(m_bodyLbl, 0, Qt::AlignVCenter);
     layout->addStretch();
 


### PR DESCRIPTION
按UI要求，消息通知标题和内容间隔4像素

Log: 修复标题与内容间距问题
Bug: https://pms.uniontech.com/bug-view-167495.html
Influence: 消息通知标题和内容间隔4像素