### PR TITLE
fix: 修复通知列表消息列表悬浮交互问题

### DIFF
--- a/dde-osd/notification-center/bubbleitem.cpp
+++ b/dde-osd/notification-center/bubbleitem.cpp
@@ -104,7 +104,7 @@ void BubbleItem::initUI()
     m_closeButton->setAccessibleName("CloseButton");
 
     setWindowFlags(Qt::Widget);
-    setFocusPolicy(Qt::StrongFocus);
+    setFocusPolicy(Qt::NoFocus);
     resize(OSD::BubbleSize(OSD::BUBBLEWIDGET));
     m_icon->setFixedSize(OSD::IconSize(OSD::BUBBLEWIDGET));
     m_closeButton->setFlat(true);
@@ -280,9 +280,8 @@ void BubbleItem::enterEvent(QEvent *event)
     if (m_view == nullptr)
         return;
     if (!QScroller::hasScroller(m_view)) {
-        setFocus();
         m_view->setCurrentRow(m_entity->currentIndex());
-        Q_EMIT havorStateChanged(true);
+        setHasFocus(true);
     }
 
     return DWidget::enterEvent(event);
@@ -293,12 +292,12 @@ void BubbleItem::leaveEvent(QEvent *event)
     // QScroller::hasScroller用于判断listview是否处于滑动状态，滑动状态不触发paint相关操作，否则滑动动画异常
     bool hasScroller = QScroller::hasScroller(m_view);
     if (!hasScroller) {
-        Q_EMIT havorStateChanged(false);
+        setHasFocus(false);
     } else {
         // 滚动结束,处理hover变化
         connect(QScroller::scroller(m_view), &QScroller::stateChanged, this, [this](const QScroller::State state){
             if (state == QScroller::Inactive) {
-                Q_EMIT havorStateChanged(false);
+                setHasFocus(false);
             }
         });
     }
@@ -308,15 +307,13 @@ void BubbleItem::leaveEvent(QEvent *event)
 
 void BubbleItem::focusInEvent(QFocusEvent *event)
 {
-    m_bgWidget->setHasFocus(true);
-    Q_EMIT havorStateChanged(true);
+    setHasFocus(true);
     return DWidget::focusInEvent(event);
 }
 
 void BubbleItem::focusOutEvent(QFocusEvent *event)
 {
-    m_bgWidget->setHasFocus(false);
-    Q_EMIT havorStateChanged(false);
+    setHasFocus(false);
     return DWidget::focusOutEvent(event);
 }
 
@@ -329,6 +326,7 @@ void BubbleItem::onHavorStateChanged(bool hover)
             QApplication::sendEvent (m_closeButton, &event);
         }
         m_appTimeLabel->setVisible(!hover);
+        update();
     }
 }
 


### PR DESCRIPTION
修复通知列表消息列表悬浮交互问题

Log: 修复通知列表消息列表悬浮交互问题
Bug: https://pms.uniontech.com/bug-view-167493.html
Influence: 修复通知列表消息列表悬浮交互问题