### PR TITLE
fix: 设置消息内容自动扩展宽度

### DIFF
--- a/dde-osd/notification-center/bubbleitem.cpp
+++ b/dde-osd/notification-center/bubbleitem.cpp
@@ -148,8 +148,8 @@ void BubbleItem::initUI()
     QHBoxLayout *bodyLayout = new QHBoxLayout;
     bodyLayout->setSpacing(0);
     bodyLayout->setContentsMargins(10, 0, 10, 0);
-    bodyLayout->addWidget(m_body);
-    bodyLayout->addWidget(m_actionButton);
+    bodyLayout->addWidget(m_body, 4);
+    bodyLayout->addWidget(m_actionButton, 0);
 
     m_bodyWidget->setLayout(bodyLayout);
     m_bodyWidget->setRadius(0, 8);


### PR DESCRIPTION
设置消息内容自动扩展宽度

Log: 修复通知消息内容显示过短问题
Bug: https://pms.uniontech.com/bug-view-167487.html
Influence: 通知消息内容显示正常宽度