### PR TITLE
fix: OSD显示绘制图标时需要根据是否显示文字计算坐标便宜量

### DIFF
--- a/dde-osd/osdprovider.cpp
+++ b/dde-osd/osdprovider.cpp
@@ -70,7 +70,7 @@ void OSDProvider::paint(QPainter *painter, const QStyleOptionViewItem &option, c
         iconPath = QString(pixPath).replace(".svg", "_dark.svg");
         color = QColor(Qt::white);
     }
-    DrawHelper::DrawImage(painter, option, iconPath, true);
+    DrawHelper::DrawImage(painter, option, iconPath, !textData.isEmpty());
 
     if (!textData.isEmpty()) {
         DrawHelper::DrawText(painter, option, textData, color);


### PR DESCRIPTION
OSD显示绘制图标时需要根据是否显示文字计算坐标偏移量

Log: 修复OSD显示wifi图标偏上的问题
Bug: https://pms.uniontech.com/bug-view-167449.html
Influence: OSD显示wifi图标居中