### PR TITLE
fix: 教育版合入专业版: 系统通知点击反应迟钝，大概率点不出来

### DIFF
--- a/dde-osd/notification/notifysettings.cpp
+++ b/dde-osd/notification/notifysettings.cpp
@@ -66,6 +66,10 @@ void NotifySettings::initAllSettings()
             continue;
         }
 
+        if (item.ID == "") {
+            continue;
+        }
+
         if (appList.contains(item.ID)) {
             // 修改系统语言后需要更新翻译
             QGSettings itemSetting(appSchemaKey.toLocal8Bit(), appSchemaPath.arg(item.ID).toLocal8Bit(), this);


### PR DESCRIPTION
fix:  修复系统通知点击反应迟钝问题

由于用户安装了steam后，系统通知收到的消息ID为空，修改增加对消息ID为空的判断解决该问题

Log: 修复系统通知点击反应迟钝问题
Bug: https://pms.uniontech.com/bug-view-91059.html
Influence: 系统通知