### PR TITLE
CMake: share code as object library, and avoid using glob

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ set(CMAKE_CXX_FLAGS "-g -Wall")
 ADD_DEFINITIONS("-fstack-protector-strong -D_FORTITY_SOURCE=1 -z noexecstack -pie -fPIC -z lazy")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fsanitize=address -O0")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=address -O0")
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
 endif()
 
 if (DEFINED ENABLE_MIEEE)
@@ -96,23 +96,9 @@ file(GLOB_RECURSE Common_SRCS
     "common/*.cpp"
     )
 
-file(GLOB_RECURSE Widgets_SRCS
-    "widgets/*.h"
-    "widgets/*.cpp"
-    )
-
-file(GLOB_RECURSE Global_Util_SRCS
-    "global_util/*.h"
-    "global_util/*.cpp"
-    )
-
-file (GLOB_RECURSE DBUS_INTERFACE_SRCS
-    "global_util/dbus/*.h"
-    "global_util/dbus/*.cpp"
-    "global_util/dbus/types/*.h"
-    "global_util/dbus/types/*.cpp"
-    )
-
+add_subdirectory("widgets")
+add_subdirectory("global_util")
+add_subdirectory("global_util/dbus")
 add_subdirectory("dde-bluetooth-dialog")
 add_subdirectory("dde-hints-dialog")
 add_subdirectory("dde-license-dialog")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(Qt5 REQUIRED COMPONENTS Widgets DBus X11Extras Xml Concurrent Svg S
 
 pkg_check_modules(GSETTINGS REQUIRED IMPORTED_TARGET gsettings-qt)
 pkg_check_modules(DdeDockInterface REQUIRED dde-dock)
-pkg_check_modules(XCB_EWMH REQUIRED xcb-ewmh)
+pkg_check_modules(XCB_EWMH REQUIRED IMPORTED_TARGET xcb-ewmh)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GIO REQUIRED gio-unix-2.0)
 pkg_check_modules(SYSTEMD REQUIRED libsystemd)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,13 +43,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 # Find the library
 find_package(PkgConfig REQUIRED)
-find_package(DtkWidget REQUIRED)
-find_package(DtkCore REQUIRED)
 find_package(GTest REQUIRED)
 find_package(GMock REQUIRED)
-find_package(Qt5 COMPONENTS Widgets DBus X11Extras Xml Concurrent Svg Sql Network Test REQUIRED)
+find_package(Dtk REQUIRED COMPONENTS Core Widget)
+find_package(Qt5 REQUIRED COMPONENTS Widgets DBus X11Extras Xml Concurrent Svg Sql Network Test)
 
-pkg_check_modules(GSETTINGS REQUIRED gsettings-qt)
+pkg_check_modules(GSETTINGS REQUIRED IMPORTED_TARGET gsettings-qt)
 pkg_check_modules(DdeDockInterface REQUIRED dde-dock)
 pkg_check_modules(XCB_EWMH REQUIRED xcb-ewmh)
 pkg_check_modules(GLIB REQUIRED glib-2.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,14 +55,6 @@ pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GIO REQUIRED gio-unix-2.0)
 pkg_check_modules(SYSTEMD REQUIRED libsystemd)
 
-include_directories(
-    common
-    global_util
-    global_util/dbus
-    global_util/dbus/types
-    widgets
-    )
-
 set(Test_Libraries
     -lpthread
     -lgcov
@@ -90,15 +82,13 @@ foreach(XMLFILE ${XMLFILES})
             WORKING_DIRECTORY ${XML2CPP_DIR})
 endforeach()
 
-#----------------------------common sources------------------------------
-file(GLOB_RECURSE Common_SRCS
-    "common/*.h"
-    "common/*.cpp"
-    )
-
+# shared objects
+add_subdirectory("common")
 add_subdirectory("widgets")
 add_subdirectory("global_util")
 add_subdirectory("global_util/dbus")
+
+# child projects
 add_subdirectory("dde-bluetooth-dialog")
 add_subdirectory("dde-hints-dialog")
 add_subdirectory("dde-license-dialog")

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set(Common_SRCS
+    accessibilitycheckerex.cpp
+    accessibilitycheckerex.h
+)
+
+add_library(session-ui-common-shared OBJECT
+    ${Widgets_SRCS}
+)
+
+target_include_directories(session-ui-common-shared
+PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_link_libraries(session-ui-common-shared
+PRIVATE
+    Qt5::Widgets
+    Dtk::Widget
+)

--- a/dde-bluetooth-dialog/src/CMakeLists.txt
+++ b/dde-bluetooth-dialog/src/CMakeLists.txt
@@ -7,7 +7,6 @@ set(Bluetooth_Dialog_Name dde-bluetooth-dialog)
 add_executable(${Bluetooth_Dialog_Name}
     ${Common_SRCS}
     ${Bluetooth_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     main.cpp
     )
 
@@ -16,6 +15,7 @@ target_include_directories(${Bluetooth_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${Bluetooth_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Bluetooth_Dialog_Libraries}
     )
 

--- a/dde-bluetooth-dialog/tests/CMakeLists.txt
+++ b/dde-bluetooth-dialog/tests/CMakeLists.txt
@@ -11,7 +11,6 @@ file(GLOB_RECURSE UT_Bluetooth_Dialog_SRCS
 add_executable(${UT_Bluetooth_Dialog_Name}
     ${Common_SRCS}
     ${Bluetooth_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     ${UT_Bluetooth_Dialog_SRCS}
     )
 
@@ -24,6 +23,7 @@ target_include_directories(${UT_Bluetooth_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${UT_Bluetooth_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Bluetooth_Dialog_Libraries}
     ${Test_Libraries}
     )

--- a/dde-osd/CMakeLists.txt
+++ b/dde-osd/CMakeLists.txt
@@ -99,6 +99,8 @@ PRIVATE
 )
 
 target_link_libraries(dde-osd-shared
+PUBLIC
+    session-ui-dbus-shared
     Dtk::Widget
     PkgConfig::GSETTINGS
     PkgConfig::XCB_EWMH

--- a/dde-osd/CMakeLists.txt
+++ b/dde-osd/CMakeLists.txt
@@ -2,17 +2,106 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-file(GLOB_RECURSE OSD_SRCS
-    "src/*.h"
-    "src/*.cpp"
-    "src/*.qrc"
-    )
+add_library(dde-osd-shared OBJECT
+    src/abstractosdprovider.cpp
+    src/abstractosdprovider.h
+    src/accessibledefine.h
+    src/accessible.h
+    src/audioprovider.cpp
+    src/audioprovider.h
+    src/brightnessprovider.cpp
+    src/brightnessprovider.h
+    src/CMakeLists.txt
+    src/common.cpp
+    src/common.h
+    src/container.cpp
+    src/container.h
+    src/delegate.cpp
+    src/delegate.h
+    src/displaymodeprovider.cpp
+    src/displaymodeprovider.h
+    src/kblayoutindicator.cpp
+    src/kblayoutindicator.h
+    src/kblayoutprovider.cpp
+    src/kblayoutprovider.h
+    src/light.qss
+    src/listview.cpp
+    src/listview.h
+    src/manager.cpp
+    src/manager.h
+    src/model.cpp
+    src/model.h
+    src/osdprovider.cpp
+    src/osdprovider.h
+    src/unittest.cpp
+    src/unittest.h
+    src/image.qrc
+    src/theme.qrc
 
-list(REMOVE_ITEM OSD_SRCS "${CMAKE_SOURCE_DIR}/dde-osd/src/main.cpp")
+    src/notification/actionbutton.cpp
+    src/notification/actionbutton.h
+    src/notification/appbody.cpp
+    src/notification/appbody.h
+    src/notification/appbodylabel.cpp
+    src/notification/appbodylabel.h
+    src/notification/appicon.cpp
+    src/notification/appicon.h
+    src/notification/bubble.cpp
+    src/notification/bubble.h
+    src/notification/bubblemanager.cpp
+    src/notification/bubblemanager.h
+    src/notification/bubbletool.cpp
+    src/notification/bubbletool.h
+    src/notification/button.cpp
+    src/notification/button.h
+    src/notification/constants.h
+    src/notification/dbus_daemon_interface.cpp
+    src/notification/dbus_daemon_interface.h
+    src/notification/dbusdockinterface.cpp
+    src/notification/dbusdockinterface.h
+    src/notification/dbuslogin1manager.cpp
+    src/notification/dbuslogin1manager.h
+    src/notification/iconbutton.cpp
+    src/notification/iconbutton.h
+    src/notification/icondata.cpp
+    src/notification/icondata.h
+    src/notification/notificationentity.cpp
+    src/notification/notificationentity.h
+    src/notification/notifications_dbus_adaptor.cpp
+    src/notification/notifications_dbus_adaptor.h
+    src/notification/notifysettings.cpp
+    src/notification/notifysettings.h
+    src/notification/persistence.cpp
+    src/notification/persistence.h
+    src/notification/signalbridge.h
 
-set(OSD_Includes
-    ${DtkWidget_INCLUDE_DIRS}
-    ${GSETTINGS_INCLUDE_DIRS}
+    src/notification-center/bubbleitem.cpp
+    src/notification-center/bubbleitem.h
+    src/notification-center/bubbletitlewidget.cpp
+    src/notification-center/bubbletitlewidget.h
+    src/notification-center/itemdelegate.cpp
+    src/notification-center/itemdelegate.h
+    src/notification-center/notifycenterwidget.cpp
+    src/notification-center/notifycenterwidget.h
+    src/notification-center/notifylistview.cpp
+    src/notification-center/notifylistview.h
+    src/notification-center/notifymodel.cpp
+    src/notification-center/notifymodel.h
+    src/notification-center/notifywidget.cpp
+    src/notification-center/notifywidget.h
+    src/notification-center/overlapwidet.cpp
+    src/notification-center/overlapwidet.h
+)
+
+target_include_directories(dde-osd-shared
+PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/src
+)
+
+target_link_libraries(dde-osd-shared
+    Dtk::Widget
+    PkgConfig::GSETTINGS
+    PkgConfig::XCB_EWMH
     Qt5::Concurrent
     Qt5::X11Extras
     Qt5::Widgets
@@ -20,20 +109,7 @@ set(OSD_Includes
     Qt5::Svg
     Qt5::Sql
     Qt5::Test
-    )
-
-set(OSD_Libraries
-    ${DtkWidget_LIBRARIES}
-    ${GSETTINGS_LIBRARIES}
-    ${XCB_EWMH_LIBRARIES}
-    Qt5::Concurrent
-    Qt5::X11Extras
-    Qt5::Widgets
-    Qt5::DBus
-    Qt5::Svg
-    Qt5::Sql
-    Qt5::Test
-    )
+)
 
 add_subdirectory("src")
 add_subdirectory("tests")

--- a/dde-osd/src/CMakeLists.txt
+++ b/dde-osd/src/CMakeLists.txt
@@ -6,7 +6,6 @@ set(OSD_Name dde-osd)
 
 add_executable(${OSD_Name}
     ${OSD_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     main.cpp
     )
 
@@ -15,6 +14,7 @@ target_include_directories(${OSD_Name} PUBLIC
     )
 
 target_link_libraries(${OSD_Name} PRIVATE
+    session-ui-dbus-shared
     ${OSD_Libraries}
     ${Test_Libraries}
     )

--- a/dde-osd/src/CMakeLists.txt
+++ b/dde-osd/src/CMakeLists.txt
@@ -5,19 +5,14 @@
 set(OSD_Name dde-osd)
 
 add_executable(${OSD_Name}
-    ${OSD_SRCS}
     main.cpp
-    )
-
-target_include_directories(${OSD_Name} PUBLIC
-    ${OSD_Includes}
-    )
+)
 
 target_link_libraries(${OSD_Name} PRIVATE
+    dde-osd-shared
     session-ui-dbus-shared
-    ${OSD_Libraries}
     ${Test_Libraries}
-    )
+)
 
 ## bin
 install(TARGETS ${OSD_Name} DESTINATION lib/deepin-daemon)

--- a/dde-osd/src/CMakeLists.txt
+++ b/dde-osd/src/CMakeLists.txt
@@ -7,6 +7,10 @@ set(OSD_Name dde-osd)
 add_executable(${OSD_Name}
     main.cpp
 )
+target_include_directories(dde-osd-shared
+PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
 
 target_link_libraries(${OSD_Name} PRIVATE
     dde-osd-shared

--- a/dde-osd/tests/CMakeLists.txt
+++ b/dde-osd/tests/CMakeLists.txt
@@ -4,21 +4,47 @@
 
 set(UT_OSD_Name ut-dde-osd)
 
-file(GLOB_RECURSE UT_OSD_SRCS
-    "*.h"
-    "*.cpp"
-    )
-
 add_executable(${UT_OSD_Name}
-    ${OSD_SRCS}
-    ${UT_OSD_SRCS}
-    )
+    mocknotifysetting.cpp
+    mocknotifysetting.h
+    mockpersistence.cpp
+    mockpersistence.h
+    ut_audioprovider.cpp
+    ut_brightnessprovider.cpp
+    ut_common.cpp
+    ut_container.cpp
+    ut_dde-osd_main.cpp
+    ut_delegate.cpp
+    ut_displaymodeprovider.cpp
+    ut_kblayoutprovider.cpp
+    ut_listview.cpp
+    ut_manager.cpp
+    ut_osdprovider.cpp
+
+    notification/ut_actionbutton.cpp
+    notification/ut_appbody.cpp
+    notification/ut_appbodylabel.cpp
+    notification/ut_appicon.cpp
+    notification/ut_bubble.cpp
+    notification/ut_bubblemanager.cpp
+    notification/ut_bubbletool.cpp
+    notification/ut_button.cpp
+    notification/ut_dockrect.cpp
+    notification/ut_iconbutton.cpp
+    notification/ut_notificationentity.cpp
+
+    notification-center/ut_bubbleitem.cpp
+    notification-center/ut_bubbletitlewidget.cpp
+    notification-center/ut_notifycenterwidget.cpp
+    notification-center/ut_notifyListview.cpp
+    notification-center/ut_notifywidget.cpp
+    notification-center/ut_overlapwidget.cpp
+)
 
 # 用于测试覆盖率的编译条件
 target_compile_options(${UT_OSD_Name} PRIVATE -fprofile-arcs -ftest-coverage)
 
 target_include_directories(${UT_OSD_Name} PUBLIC
-    ${OSD_Includes}
     Qt5::Test
     ../src/
     ../src/notification/
@@ -26,8 +52,8 @@ target_include_directories(${UT_OSD_Name} PUBLIC
     )
 
 target_link_libraries(${UT_OSD_Name} PRIVATE
+    dde-osd-shared
     session-ui-dbus-shared
-    ${OSD_Libraries}
     Qt5::Test
     ${Test_Libraries}
     )

--- a/dde-osd/tests/CMakeLists.txt
+++ b/dde-osd/tests/CMakeLists.txt
@@ -12,7 +12,6 @@ file(GLOB_RECURSE UT_OSD_SRCS
 add_executable(${UT_OSD_Name}
     ${OSD_SRCS}
     ${UT_OSD_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     )
 
 # 用于测试覆盖率的编译条件
@@ -27,6 +26,7 @@ target_include_directories(${UT_OSD_Name} PUBLIC
     )
 
 target_link_libraries(${UT_OSD_Name} PRIVATE
+    session-ui-dbus-shared
     ${OSD_Libraries}
     Qt5::Test
     ${Test_Libraries}

--- a/dde-osd/tests/notification/ut_dockrect.cpp
+++ b/dde-osd/tests/notification/ut_dockrect.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #define private public
-#include "dockrect.h"
+#include "types/dockrect.h"
 #undef private
 
 #include <QDebug>

--- a/dde-suspend-dialog/src/CMakeLists.txt
+++ b/dde-suspend-dialog/src/CMakeLists.txt
@@ -6,7 +6,6 @@ set(Suspend_Dialog_Name dde-suspend-dialog)
 
 add_executable(${Suspend_Dialog_Name}
     ${Suspend_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     main.cpp
     )
 
@@ -15,6 +14,7 @@ target_include_directories(${Suspend_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${Suspend_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Suspend_Dialog_Libraries}
     )
 

--- a/dde-suspend-dialog/tests/CMakeLists.txt
+++ b/dde-suspend-dialog/tests/CMakeLists.txt
@@ -11,7 +11,6 @@ file(GLOB_RECURSE UT_Suspend_Dialog_SRCS
 add_executable(${UT_Suspend_Dialog_Name}
     ${Suspend_Dialog_SRCS}
     ${UT_Suspend_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     )
 
 # 用于测试覆盖率的编译条件
@@ -25,6 +24,7 @@ target_include_directories(${UT_Suspend_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${UT_Suspend_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Suspend_Dialog_Libraries}
     ${Test_Libraries}
     Qt5::Test

--- a/dde-touchscreen-dialog/src/CMakeLists.txt
+++ b/dde-touchscreen-dialog/src/CMakeLists.txt
@@ -6,7 +6,6 @@ set(Touchscreen_Dialog_Name dde-touchscreen-dialog)
 
 add_executable(${Touchscreen_Dialog_Name}
     ${Touchscreen_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     main.cpp
     )
 
@@ -15,6 +14,7 @@ target_include_directories(${Touchscreen_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${Touchscreen_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Touchscreen_Dialog_Libraries}
     )
 

--- a/dde-touchscreen-dialog/tests/CMakeLists.txt
+++ b/dde-touchscreen-dialog/tests/CMakeLists.txt
@@ -11,7 +11,6 @@ file(GLOB_RECURSE UT_Touchscreen_Dialog_SRCS
 add_executable(${UT_Touchscreen_Dialog_Name}
     ${Touchscreen_Dialog_SRCS}
     ${UT_Touchscreen_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     )
 
 # 用于测试覆盖率的编译条件
@@ -24,6 +23,7 @@ target_include_directories(${UT_Touchscreen_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${UT_Touchscreen_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Touchscreen_Dialog_Libraries}
     ${Test_Libraries}
     )

--- a/dde-welcome/CMakeLists.txt
+++ b/dde-welcome/CMakeLists.txt
@@ -2,28 +2,22 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-file(GLOB_RECURSE Welcome_SRCS
-    "src/*.h"
-    "src/*.cpp"
-    )
+add_library(dde-welcome-shared OBJECT
+    "src/mainwidget.cpp"
+    "src/mainwidget.h"
+    "src/updatecontent.cpp"
+    "src/updatecontent.h"
+    "src/utils.cpp"
+    "src/utils.h"
+)
 
-list(REMOVE_ITEM Welcome_SRCS "${CMAKE_SOURCE_DIR}/dde-welcome/src/main.cpp")
-
-set(Welcome_Includes
-    ${DtkWidget_INCLUDE_DIRS}
-    ${GSETTINGS_INCLUDE_DIRS}
+target_link_libraries(dde-welcome-shared
+    Dtk::Widget
+    PkgConfig::GSETTINGS
     Qt5::Widgets
     Qt5::DBus
     Qt5::Xml
-    )
-
-set(Welcome_Libraries
-    ${DtkWidget_LIBRARIES}
-    ${GSETTINGS_LIBRARIES}
-    Qt5::Widgets
-    Qt5::DBus
-    Qt5::Xml
-    )
+)
 
 add_subdirectory("src")
 add_subdirectory("tests")

--- a/dde-welcome/CMakeLists.txt
+++ b/dde-welcome/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(dde-welcome-shared OBJECT
 )
 
 target_link_libraries(dde-welcome-shared
+    session-ui-widgets-shared
+    session-ui-dbus-shared
     Dtk::Widget
     PkgConfig::GSETTINGS
     Qt5::Widgets

--- a/dde-welcome/src/CMakeLists.txt
+++ b/dde-welcome/src/CMakeLists.txt
@@ -5,14 +5,15 @@
 set(Welcome_Name dde-welcome)
 
 add_executable(${Welcome_Name}
-    ${Widgets_SRCS}
-    ${Global_Util_SRCS}
     main.cpp
 )
 
 target_link_libraries(${Welcome_Name}
 PRIVATE
     dde-welcome-shared
+    session-ui-widgets-shared
+    session-ui-util-shared
+    session-ui-dbus-shared
 )
 
 ## bin

--- a/dde-welcome/src/CMakeLists.txt
+++ b/dde-welcome/src/CMakeLists.txt
@@ -5,20 +5,15 @@
 set(Welcome_Name dde-welcome)
 
 add_executable(${Welcome_Name}
-    ${Welcome_SRCS}
     ${Widgets_SRCS}
     ${Global_Util_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     main.cpp
-    )
+)
 
-target_include_directories(${Welcome_Name} PUBLIC
-    ${Welcome_Includes}
-    )
-
-target_link_libraries(${Welcome_Name} PRIVATE
-    ${Welcome_Libraries}
-    )
+target_link_libraries(${Welcome_Name}
+PRIVATE
+    dde-welcome-shared
+)
 
 ## bin
 install(TARGETS ${Welcome_Name} DESTINATION lib/deepin-daemon)

--- a/dde-welcome/tests/CMakeLists.txt
+++ b/dde-welcome/tests/CMakeLists.txt
@@ -5,9 +5,6 @@
 set(UT_Welcome_Name ut-dde-welcome)
 
 add_executable(${UT_Welcome_Name}
-    ${Widgets_SRCS}
-    ${Global_Util_SRCS}
-
     "main.cpp"
     "ut_mainwidget.cpp"
     "ut_updatecontent.cpp"
@@ -27,6 +24,9 @@ target_include_directories(${UT_Welcome_Name} PUBLIC
 
 target_link_libraries(${UT_Welcome_Name} PRIVATE
     dde-welcome-shared
+    session-ui-widgets-shared
+    session-ui-util-shared
+    session-ui-dbus-shared
     ${Test_Libraries}
     Qt5::Test
 )

--- a/dde-welcome/tests/CMakeLists.txt
+++ b/dde-welcome/tests/CMakeLists.txt
@@ -4,29 +4,29 @@
 
 set(UT_Welcome_Name ut-dde-welcome)
 
-file(GLOB_RECURSE UT_Welcome_SRCS
-    "*.h"
-    "*.cpp"
-    )
 add_executable(${UT_Welcome_Name}
-    ${Welcome_SRCS}
     ${Widgets_SRCS}
     ${Global_Util_SRCS}
-    ${UT_Welcome_SRCS}
-    ${DBUS_INTERFACE_SRCS}
-    )
+
+    "main.cpp"
+    "ut_mainwidget.cpp"
+    "ut_updatecontent.cpp"
+    "global_util/ut_multiscreenmanager.cpp"
+    "global_util/ut_publicfunc.cpp"
+    "global_util/ut_utilupdateui.cpp"
+    "widgets/ut_fullscreenbackground.cpp"
+    "widgets/ut_propertygroup.cpp"
+)
 
 # 用于测试覆盖率的编译条件
 target_compile_options(${UT_Welcome_Name} PRIVATE -fprofile-arcs -ftest-coverage)
 
 target_include_directories(${UT_Welcome_Name} PUBLIC
-    ${Welcome_Includes}
-    Qt5::Test
     ../src/
-    )
+)
 
 target_link_libraries(${UT_Welcome_Name} PRIVATE
-    ${Welcome_Libraries}
+    dde-welcome-shared
     ${Test_Libraries}
     Qt5::Test
-    )
+)

--- a/dde-wm-chooser/src/CMakeLists.txt
+++ b/dde-wm-chooser/src/CMakeLists.txt
@@ -6,9 +6,6 @@ set(Wm_Chooser_Name dde-wm-chooser)
 
 add_executable(${Wm_Chooser_Name}
     ${Wm_Chooser_SRCS}
-    ${Widgets_SRCS}
-    ${Global_Util_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     main.cpp
     )
 
@@ -17,6 +14,9 @@ target_include_directories(${Wm_Chooser_Name} PUBLIC
     )
 
 target_link_libraries(${Wm_Chooser_Name} PRIVATE
+    session-ui-widgets-shared
+    session-ui-util-shared
+    session-ui-dbus-shared
     ${Wm_Chooser_Libraries}
     )
 

--- a/dde-wm-chooser/tests/CMakeLists.txt
+++ b/dde-wm-chooser/tests/CMakeLists.txt
@@ -11,10 +11,7 @@ file(GLOB_RECURSE UT_Wm_Chooser_SRCS
 
 add_executable(${UT_Wm_Chooser_Name}
     ${Wm_Chooser_SRCS}
-    ${Widgets_SRCS}
-    ${Global_Util_SRCS}
     ${UT_Wm_Chooser_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     )
 
 # 用于测试覆盖率的编译条件
@@ -27,6 +24,9 @@ target_include_directories(${UT_Wm_Chooser_Name} PUBLIC
     )
 
 target_link_libraries(${UT_Wm_Chooser_Name} PRIVATE
+    session-ui-widgets-shared
+    session-ui-util-shared
+    session-ui-dbus-shared
     ${Wm_Chooser_Libraries}
     ${Test_Libraries}
     Qt5::Test

--- a/dmemory-warning-dialog/src/CMakeLists.txt
+++ b/dmemory-warning-dialog/src/CMakeLists.txt
@@ -6,7 +6,6 @@ set(Dmemory_Warning_Dialog_Name dmemory-warning-dialog)
 
 add_executable(${Dmemory_Warning_Dialog_Name}
     ${Dmemory_Warning_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     main.cpp
     )
 
@@ -15,6 +14,7 @@ target_include_directories(${Dmemory_Warning_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${Dmemory_Warning_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Dmemory_Warning_Dialog_Libraries}
     )
 

--- a/dmemory-warning-dialog/tests/CMakeLists.txt
+++ b/dmemory-warning-dialog/tests/CMakeLists.txt
@@ -11,7 +11,6 @@ file(GLOB_RECURSE UT_Dmemory_Warning_Dialog_SRCS
 add_executable(${UT_Dmemory_Warning_Dialog_Name}
     ${Dmemory_Warning_Dialog_SRCS}
     ${UT_Dmemory_Warning_Dialog_SRCS}
-    ${DBUS_INTERFACE_SRCS}
     )
 
 # 用于测试覆盖率的编译条件
@@ -24,6 +23,7 @@ target_include_directories(${UT_Dmemory_Warning_Dialog_Name} PUBLIC
     )
 
 target_link_libraries(${UT_Dmemory_Warning_Dialog_Name} PRIVATE
+    session-ui-dbus-shared
     ${Dmemory_Warning_Dialog_Libraries}
     ${Test_Libraries}
     Qt5::Test

--- a/global_util/CMakeLists.txt
+++ b/global_util/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(Global_Util_SRCS
+    multiscreenmanager.cpp
+    multiscreenmanager.h
+    public_func.cpp
+    public_func.h
+    util_updateui.cpp
+    util_updateui.h
+)
+
+add_library(session-ui-util-shared OBJECT
+    ${Global_Util_SRCS}
+)
+
+target_include_directories(session-ui-util-shared
+PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_link_libraries(session-ui-util-shared
+PRIVATE
+    Qt5::Widgets
+    Dtk::Core
+)

--- a/global_util/CMakeLists.txt
+++ b/global_util/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 set(Global_Util_SRCS
     multiscreenmanager.cpp
     multiscreenmanager.h

--- a/global_util/dbus/CMakeLists.txt
+++ b/global_util/dbus/CMakeLists.txt
@@ -1,0 +1,90 @@
+set (SESSION_UI_DBUS_INTERFACE_SRCS
+    com_deepin_chromeextension_tabslimit.cpp
+    com_deepin_chromeextension_tabslimit.h
+    org_deepin_dde_accounts1.cpp
+    org_deepin_dde_accounts1.h
+    org_deepin_dde_accounts1_user.cpp
+    org_deepin_dde_accounts1_user.h
+    org_deepin_dde_appearance1.cpp
+    org_deepin_dde_appearance1.h
+    org_deepin_dde_audio1.cpp
+    org_deepin_dde_audio1.h
+    org_deepin_dde_audio1_sink.cpp
+    org_deepin_dde_audio1_sink.h
+    org_deepin_dde_bluetooth1.cpp
+    org_deepin_dde_bluetooth1.h
+    org_deepin_dde_daemon_dock1.cpp
+    org_deepin_dde_daemon_dock1.h
+    org_deepin_dde_daemon_launcherd1.cpp
+    org_deepin_dde_daemon_launcherd1.h
+    org_deepin_dde_display1.cpp
+    org_deepin_dde_display1.h
+    org_deepin_dde_display1_monitor.cpp
+    org_deepin_dde_display1_monitor.h
+    org_deepin_dde_gesture1.cpp
+    org_deepin_dde_gesture1.h
+    org_deepin_dde_imageblur1.cpp
+    org_deepin_dde_imageblur1.h
+    org_deepin_dde_inputdevice1_keyboard.cpp
+    org_deepin_dde_inputdevice1_keyboard.h
+    org_deepin_dde_notification1.cpp
+    org_deepin_dde_notification1.h
+    org_deepin_dde_sessionmanager1.cpp
+    org_deepin_dde_sessionmanager1.h
+    org_deepin_dde_soundeffect1.cpp
+    org_deepin_dde_soundeffect1.h
+    org_deepin_dde_startmanager1.cpp
+    org_deepin_dde_startmanager1.h
+
+    types/appscgroupinfo.h
+    types/appscgroupinfolist.cpp
+    types/appscgroupinfolist.h
+    types/audioport.cpp
+    types/audioport.h
+    types/audioportlist.cpp
+    types/audioportlist.h
+    types/brightnessmap.cpp
+    types/brightnessmap.h
+    types/dockrect.cpp
+    types/dockrect.h
+    types/keyboardlayoutlist.cpp
+    types/keyboardlayoutlist.h
+    types/launcheriteminfo.cpp
+    types/launcheriteminfo.h
+    types/launcheriteminfolist.cpp
+    types/launcheriteminfolist.h
+    types/qrect.h
+    types/qvariantmap.cpp
+    types/qvariantmap.h
+    types/reflectlist.cpp
+    types/reflectlist.h
+    types/resolution.cpp
+    types/resolution.h
+    types/resolutionlist.cpp
+    types/resolutionlist.h
+    types/rotationlist.cpp
+    types/rotationlist.h
+    types/screenrect.cpp
+    types/screenrect.h
+    types/touchscreeninfolist.cpp
+    types/touchscreeninfolist.h
+    types/touchscreeninfolist_v2.cpp
+    types/touchscreeninfolist_v2.h
+    types/touchscreenmap.cpp
+    types/touchscreenmap.h
+)
+
+add_library(session-ui-dbus-shared OBJECT
+    ${SESSION_UI_DBUS_INTERFACE_SRCS}
+)
+
+target_include_directories(session-ui-dbus-shared
+PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_link_libraries(session-ui-dbus-shared
+PRIVATE
+    Qt5::DBus
+    Dtk::Core
+)

--- a/global_util/dbus/CMakeLists.txt
+++ b/global_util/dbus/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 set (SESSION_UI_DBUS_INTERFACE_SRCS
     com_deepin_chromeextension_tabslimit.cpp
     com_deepin_chromeextension_tabslimit.h

--- a/reset-password-dialog/CMakeLists.txt
+++ b/reset-password-dialog/CMakeLists.txt
@@ -66,7 +66,7 @@ find_package(DtkGui REQUIRED)
 pkg_check_modules(DeepinPwCheck REQUIRED IMPORTED_TARGET libdeepin_pw_check)
 
 
-add_executable(${BIN_NAME} ${SRCS} ${QRC} ${DBUS_INTERFACE_SRCS})
+add_executable(${BIN_NAME} ${SRCS} ${QRC})
 target_include_directories(${BIN_NAME} PUBLIC
     ${DtkWidget_INCLUDE_DIRS}
     ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
@@ -74,6 +74,7 @@ target_include_directories(${BIN_NAME} PUBLIC
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
+    session-ui-dbus-shared
     ${DtkWidget_LIBRARIES}
     ${Qt5Widgets_LIBRARIES}
     ${Qt5Network_LIBRARIES}

--- a/widgets/CMakeLists.txt
+++ b/widgets/CMakeLists.txt
@@ -1,0 +1,18 @@
+file(GLOB_RECURSE Widgets_SRCS
+    "*.h"
+    "*.cpp"
+)
+
+add_library(session-ui-widgets-shared OBJECT
+    ${Widgets_SRCS}
+)
+
+target_include_directories(session-ui-widgets-shared
+PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_link_libraries(session-ui-widgets-shared
+PRIVATE
+    Qt5::Widgets
+)

--- a/widgets/CMakeLists.txt
+++ b/widgets/CMakeLists.txt
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-file(GLOB_RECURSE Widgets_SRCS
-    "*.h"
-    "*.cpp"
+set(Widgets_SRCS
+    fullscreenbackground.cpp
+    fullscreenbackground.h
+    propertygroup.cpp
+    propertygroup.h
 )
 
 add_library(session-ui-widgets-shared OBJECT

--- a/widgets/CMakeLists.txt
+++ b/widgets/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 file(GLOB_RECURSE Widgets_SRCS
     "*.h"
     "*.cpp"


### PR DESCRIPTION
避免将相同的源码添加到不同的子项目来减少不必要的构建，加快构建时间。并通过使用 GLOB 来使得 CMake 知道哪些源码需要重新进行构建，进一步简短再次构建时的构建时间。
