### PR TITLE
chore: bump version to 6.0.7

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[deepin-desktop-environment.dde-session-ui]
+[o:linuxdeepin:p:deepin-desktop-environment:r:dde-session-ui]
 file_filter = translations/dde-session-ui_<lang>.ts
 minimum_perc = 0
 source_file = translations/dde-session-ui.ts

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-session-ui (6.0.7) unstable; urgency=medium
+
+  * Avoid use GLOB for some subprojects (dde-osd, dde-welcome, etc)
+  * Reuse common utils as object libraries
+  * Ensure project source compliant with REUSE spec
+  * Fix dde-osd window round radius conflicting with blur effect
+  * Change the value of XDG_CURRENT_DESKTOP to DDE
+
+ -- Wang Zichong <wangzichong@deepin.org>  Tue, 28 Mar 2023 17:01:00 +0800
+
 dde-session-ui (6.0.6) unstable; urgency=medium
 
   [ TagBuilder ]


### PR DESCRIPTION
  * Avoid use GLOB for some subprojects (dde-osd, dde-welcome, etc)
  * Reuse common utils as object libraries
  * Ensure project source compliant with REUSE spec
  * Fix dde-osd window round radius conflicting with blur effect
  * Change the value of XDG_CURRENT_DESKTOP to DDE
