### PR TITLE
fix: when id is empty osd break, and wrong gsetting

### DIFF
--- a/dde-osd/src/container.cpp
+++ b/dde-osd/src/container.cpp
@@ -119,7 +119,7 @@ void Container::updateWindowRadius(int radius)
 void Container::onDelayQuit()
 {
     const QGSettings gsettings("com.deepin.dde.osd", "/com/deepin/dde/osd/");
-    if (gsettings.keys().contains("autoExit") && gsettings.get("auto-exit").toBool()) {
+    if (gsettings.keys().contains("auto-exit") && gsettings.get("auto-exit").toBool()) {
         if (isVisible())
             return m_quitTimer->start();
         qWarning() << "Killer Timeout, now quiting...";

--- a/dde-osd/src/notification/notifysettings.cpp
+++ b/dde-osd/src/notification/notifysettings.cpp
@@ -86,6 +86,9 @@ void NotifySettings::initAllSettings()
 
 void NotifySettings::setAppSetting(const QString &id, const NotifySettings::AppConfigurationItem &item, const QVariant &var)
 {
+    if (id.isEmpty()) {
+        return;
+    }
     QGSettings itemSetting(appSchemaKey.toLocal8Bit(), appSchemaPath.arg(id).toLocal8Bit(), this);
     switch (item) {
     case APPNAME:
@@ -123,7 +126,8 @@ void NotifySettings::setAppSetting(const QString &id, const NotifySettings::AppC
 
 QVariant NotifySettings::getAppSetting(const QString &id, const NotifySettings::AppConfigurationItem &item)
 {
-    QGSettings itemSetting(appSchemaKey.toLocal8Bit(), appSchemaPath.arg(id).toLocal8Bit(), this);
+    const QString newid = id.isEmpty() ? "empty-app" : id;
+    QGSettings itemSetting(appSchemaKey.toLocal8Bit(), appSchemaPath.arg(newid).toLocal8Bit(), this);
 
     QVariant results;
     switch (item) {


### PR DESCRIPTION
Log: fix when is id empty, osd break

这样就可以复现
```bash
gdbus call --session  \
--dest org.freedesktop.Notifications \
--object-path /org/freedesktop/Notifications \
--method org.freedesktop.Notifications.Notify \
"" \
42 \
"" \
"The Summary"\ 
"Here's the body of the notification" \ 
[] \
{} \
5000
```