### PR TITLE
Revert "fix: 修复玲珑应用通知无法跳转"

### DIFF
--- a/dde-osd/src/notification/bubbletool.h
+++ b/dde-osd/src/notification/bubbletool.h
@@ -26,7 +26,6 @@ public:
     static void actionInvoke(const QString &actionId, EntityPtr entity);//从entity提取出命令信息,执行命令产生相应动作
     static void register_wm_state(WId winid);//保持气泡窗口置顶
     static const QString getDeepinAppName(const QString &name);//获取应用名称
-    static const QString getDeepinDesktopPath(const QString &name);//获取desktop文件路径
 
 private:
     /*!


### PR DESCRIPTION
该提交导致了其他问题，应用名称不一定是desktop文件的前缀，
需换另一种方式实现玲珑应用响应通知的场景。