### PR TITLE
feat: launch the application by AM in actionInvoke

### DIFF
--- a/dde-osd/src/notification/bubbletool.h
+++ b/dde-osd/src/notification/bubbletool.h
@@ -26,6 +26,7 @@ public:
     static void actionInvoke(const QString &actionId, EntityPtr entity);//从entity提取出命令信息,执行命令产生相应动作
     static void register_wm_state(WId winid);//保持气泡窗口置顶
     static const QString getDeepinAppName(const QString &name);//获取应用名称
+    static const QString getDeepinDesktopPath(const QString &name);//获取desktop文件路径
 
 private:
     /*!


### PR DESCRIPTION
We can't call an application up by QProcess if it is running in a sandbox. So we add a new way to call it.

Log: