### PR TITLE
fix: Can't update password for dnetwork-secret-dialog

### DIFF
--- a/dde-pixmix/src/main.cpp
+++ b/dde-pixmix/src/main.cpp
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QImageReader>
+#include <QFileInfo>
 
 #include <DApplication>
 #include <DGuiApplicationHelper>

--- a/dnetwork-secret-dialog/src/main.cpp
+++ b/dnetwork-secret-dialog/src/main.cpp
@@ -13,6 +13,7 @@
 
 #include <QCommandLineOption>
 #include <QCommandLineParser>
+#include <QTranslator>
 
 DCORE_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE

--- a/dnetwork-secret-dialog/src/main.cpp
+++ b/dnetwork-secret-dialog/src/main.cpp
@@ -25,7 +25,6 @@ int main(int argc, char *argv[])
     app.setApplicationName("dnetwork-secret-dialog");
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-    DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();
 
     QTranslator translator;

--- a/dnetwork-secret-dialog/src/main.cpp
+++ b/dnetwork-secret-dialog/src/main.cpp
@@ -46,27 +46,31 @@ int main(int argc, char *argv[])
     if (posArguments.isEmpty()) {
         qDebug() << "read json data from STDIN";
         if (!file.open(stdin, QFile::ReadOnly)) {
-            qDebug() << "read from STDIN failed";
+            qWarning() << "read from STDIN failed";
             return -2;
         }
     } else {
         file.setFileName(posArguments.first());
         if (!file.open(QFile::ReadOnly)) {
-            qDebug() << "file:" << file.fileName()<< "open failed";
+            qWarning() << "file:" << file.fileName()<< "open failed";
             return -1;
         }
     }
 
     jsonDoc = QJsonDocument::fromJson(file.readAll());
     if (jsonDoc.isEmpty()) {
-        qDebug() << "invalid json data.";
+        qWarning() << "invalid json data.";
         return -3;
     }
 
     file.close();
 
     NetworkDialog *networkDialog = new NetworkDialog();
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, [networkDialog]() {
+        networkDialog->deleteLater();
+    });
     if (networkDialog->exec(jsonDoc)) { // 不能处理就由原窗口处理
+        qInfo() << "Enter event loop to receive data in NetworkDialog.";
         return app.exec();
     }
 


### PR DESCRIPTION
  DLogManager's console has changed from std::cerr to std::out
in the commit 24a29a0f9f60a393e0b34f8b2b5d0ec9ea5bdcd1 , It will affect the interaction between dnetwork-secret-dialog and dde-session-daemon.
  And the tool doesn't need ConsoleAppender for log.

Issue: https://github.com/linuxdeepin/developer-center/issues/5284