### PR TITLE
fix: don't override CMAKE_EXE_LINKER_FLAGS

### DIFF
--- a/reset-password-dialog/CMakeLists.txt
+++ b/reset-password-dialog/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_FLAGS "-g -Wall")
 # 增加安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
-set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie")
+set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -z relro -z now -z noexecstack -pie")
 
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ftree-vectorize -march=loongson3a -mhard-float -mno-micromips -mno-mips16 -flax-vector-conversions -mloongson-ext2 -mloongson-mmi")


### PR DESCRIPTION
Append to CMAKE_EXE_LINKER_FLAGS instead of overwriting it.