### PR TITLE
fix: missing notification for NotifyCenter

### DIFF
--- a/dde-osd/src/notification/bubblemanager.cpp
+++ b/dde-osd/src/notification/bubblemanager.cpp
@@ -863,6 +863,8 @@ bool BubbleManager::calcReplaceId(EntityPtr notify)
             if (bubble->entity()->replacesId() == notify->replacesId()
                     && bubble->entity()->appName() == notify->appName()) {
                 m_persistence->addOne(m_bubbleList.at(i)->entity());
+                // emit RecordAdded for notProcessedYet entity
+                Q_EMIT RecordAdded(m_bubbleList.at(i)->entity()->storageId());
                 if (i != 0) {
                     bubble->setEntity(m_bubbleList.at(i)->entity());
                 }
@@ -876,6 +878,11 @@ bool BubbleManager::calcReplaceId(EntityPtr notify)
                     && m_oldEntities.at(i)->appName() == notify->appName()) {
                 m_oldEntities.removeAt(i);
             }
+        }
+        if (find) {
+            // Add persistence for Replace Entity.
+            if (notify->isShowInNotifyCenter())
+                m_persistence->addOne(notify);
         }
     }
 

--- a/dde-osd/src/notification/persistence.cpp
+++ b/dde-osd/src/notification/persistence.cpp
@@ -127,7 +127,7 @@ uint Persistence::doAddOne(EntityPtr entity)
         m_query.next();
         entity->setStorageId(m_query.value(0).toString());
 #ifdef QT_DEBUG
-        qDebug() << "get entity's id done:" << entity->id();
+        qDebug() << "get entity's id done:" << entity->id() << entity->storageId();
 #endif
     }
     return 1;


### PR DESCRIPTION
  We add notification to Persistence for Replace Notification, and
wheather it emits RecordAdded signal depends on Bubble's notProcessedYet.
and emitting signal for replaced notification,

Issue: https://github.com/linuxdeepin/developer-center/issues/6930
