### PR TITLE
fix: the number of notifications is incorrect

### DIFF
--- a/dde-osd/src/notification/bubblemanager.h
+++ b/dde-osd/src/notification/bubblemanager.h
@@ -262,6 +262,8 @@ private:
     void popAllBubblesImmediately();
 
     bool useBuiltinBubble() const;
+    void emitRecordAdded(EntityPtr notify);
+    void emitRecordAdded(const QString &id);
 private:
     int m_replaceCount = 0;
     QString m_configFile;


### PR DESCRIPTION
  for replaced notification, we should remove the old one in db,
then add new one record(we also can update the old one).
  Add other scenarios of forgetting to trigger `RecordAdded` signals.

Issue: https://github.com/linuxdeepin/developer-center/issues/6952
