### PR TITLE
chore: notify settings and icon tweak

### DIFF
--- a/dde-osd/src/notification/notifysettings.h
+++ b/dde-osd/src/notification/notifysettings.h
@@ -92,6 +92,7 @@ private:
     QTimer *m_initTimer;
     QGSettings *m_systemSetting;
     ApplicationObjectManager1 *m_applicationObjectInter;
+    LauncherItemInfoList m_launcherItemInfoList;
 };
 
 #endif // NOTIFYSETTINGS_H

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-ui (6.0.19) unstable; urgency=medium
+
+  * release 6.0.19
+
+ -- Mike Chen <chenke@deepin.org>  Thu, 23 May 2024 14:11:46 +0800
+
 dde-session-ui (6.0.18) unstable; urgency=medium
 
   * fix: wrong position of notification

--- a/global_util/dbus/types/launcheriteminfo.cpp
+++ b/global_util/dbus/types/launcheriteminfo.cpp
@@ -22,5 +22,10 @@
 
 bool LauncherItemInfo::operator!=(const LauncherItemInfo &itemInfo)
 {
-    return itemInfo.path != path;
+    return !operator==(itemInfo);
+}
+
+bool LauncherItemInfo::operator==(const LauncherItemInfo &itemInfo)
+{
+    return itemInfo.path == path;
 }

--- a/global_util/dbus/types/launcheriteminfo.h
+++ b/global_util/dbus/types/launcheriteminfo.h
@@ -32,12 +32,14 @@ struct LauncherItemInfo {
     qint64 categoryId;
     qint64 timeInstalled;
     QStringList keywords;
+    QStringList names;
     bool noDisplay;
     bool operator!=(const LauncherItemInfo &versionInfo);
+    bool operator==(const LauncherItemInfo &versionInfo);
 
     friend QDebug operator<<(QDebug argument, const LauncherItemInfo &info)
     {
-        argument << info.path << info.name << info.id;
+        argument << info.path << info.names << info.id;
         argument << info.icon << info.categoryId << info.timeInstalled << info.keywords << info.noDisplay;
 
         return argument;


### PR DESCRIPTION
chore: notify settings and icon tweak
- get appid from AM first(pid ==> appid)
- get appid from cached item info(.names)
- if icon is empty get icon from settings
- GenericName[lang] first then Name[lang]
- alwayays update icon and name in initAllSettings
linux.qq.com desktop 名是 qq.desktop 即 appID 是 qq ， 但是通知时 AppName 是QQ

Issue: https://github.com/linuxdeepin/developer-center/issues/8281
Issue: https://github.com/linuxdeepin/developer-center/issues/6907

b4:
![image](https://github.com/linuxdeepin/dde-session-ui/assets/23466548/be42deae-c77f-4860-adc3-17c40a1322d5)

now:
![image](https://github.com/linuxdeepin/dde-session-ui/assets/23466548/42f0ccf6-8710-4ce6-9162-a83dc84b6307)

