### PR TITLE
chore: bump version to 6.0.20

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-session-ui (6.0.20) unstable; urgency=medium
+
+  * fix: the text not being vertically centered (linuxdeepin/developer-center#8899)
+  * fix: incorrect X-Deepin-Vendor check for LauncherItemInfo
+  * fix: notification record count could be -1
+
+ -- zsien <quezhiyong@deepin.org>  Mon, 17 Jun 2024 13:25:39 +0800
+
 dde-session-ui (6.0.19) unstable; urgency=medium
 
   * release 6.0.19


### PR DESCRIPTION
  * fix: the text not being vertically centered (linuxdeepin/developer-center#8899)
  * fix: incorrect X-Deepin-Vendor check for LauncherItemInfo
  * fix: notification record count could be -1