### PR TITLE
chore: 解决dde-pixmix在root下执行崩溃的问题

### DIFF
--- a/dde-pixmix/src/main.cpp
+++ b/dde-pixmix/src/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
     a.setApplicationName("dde-pixmix");
 
     DLogManager::registerConsoleAppender();
-    DLogManager::registerFileAppender();
+    DLogManager::registerJournalAppender();
 
     QCommandLineOption option(QStringList() << "o" << "output", "Output suitable background image.");
     option.setValueName("path");


### PR DESCRIPTION
解决dde-pixmix在root下执行崩溃的问题
Issue: https://github.com/linuxdeepin/developer-center/issues/10310