### PR TITLE
fix: window removes its own display animation

### DIFF
--- a/dde-osd/src/notification-center/notifycenterwidget.cpp
+++ b/dde-osd/src/notification-center/notifycenterwidget.cpp
@@ -299,7 +299,8 @@ void NotifyCenterWidget::unRegisterRegion()
 
 void NotifyCenterWidget::CompositeChanged()
 {
-    m_hasComposite = m_wmHelper->hasComposite();
+    // 屏蔽应用自己的动画，默认使用窗管窗口显示动画
+    m_hasComposite = false;
 }
 
 void NotifyCenterWidget::setX(int x)


### PR DESCRIPTION
as title

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9728