### PR TITLE
chore: remove startdde dependency

### DIFF
--- a/dde-blackwidget/src/window.cpp
+++ b/dde-blackwidget/src/window.cpp
@@ -34,7 +34,7 @@ Window::Window(QWidget *parent)
     QCursor cursor(Qt::BlankCursor);
     this->setCursor(cursor);
 
-    DTK_CORE_NAMESPACE::DConfig *dsgConfig = DTK_CORE_NAMESPACE::DConfig::create("org.deepin.startdde", QString("org.deepin.Display"));
+    DTK_CORE_NAMESPACE::DConfig *dsgConfig = DTK_CORE_NAMESPACE::DConfig::create("org.deepin.dde.daemon", QString("org.deepin.Display"));
     if (dsgConfig && dsgConfig->isValid() && dsgConfig->keyList().contains("gravity-rotate-black-enabled")) {
         m_gravityRotateBlackEnabled = dsgConfig->value("gravity-rotate-black-enabled").toBool();
         dsgConfig->deleteLater();

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-ui (6.0.27) unstable; urgency=medium
+
+  * chore: remove startdde dependency
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 02 Apr 2025 11:29:43 +0800
+
 dde-session-ui (6.0.26) unstable; urgency=medium
 
   * fix: Low battery window not translated

--- a/debian/control
+++ b/debian/control
@@ -26,8 +26,7 @@ Package: dde-session-ui
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends},
  deepin-desktop-schemas (>= 5.9.14),
- dde-daemon (>=5.13.27),
- startdde (>=5.8.15),
+ dde-daemon (>=6.1.26),
  x11-xserver-utils,
  dbus-user-session,
  dde-session-shell


### PR DESCRIPTION
remove startdde dependency

Log: remove startdde dependency
pms: TASK-374777

## Summary by Sourcery

Chores:
- Replace startdde configuration namespace with a more generic DDE daemon namespace