### PR TITLE
fix: Display name truncation

### DIFF
--- a/dde-touchscreen-dialog/src/recognizedialog.cpp
+++ b/dde-touchscreen-dialog/src/recognizedialog.cpp
@@ -57,7 +57,7 @@ void RecognizeDialog::paintEvent(QPaintEvent *event)
     const QFontMetrics fm(font);
 
     QPainterPath path;
-    path.addText(m_rect.width() - fm.horizontalAdvance(m_text) / 2.0, m_rect.height() - VerticalMargin - fm.height() / 4.0, font, m_text);
+    path.addText((m_rect.width() - fm.horizontalAdvance(m_text)) / 2.0, m_rect.height() - VerticalMargin - fm.height() / 4.0, font, m_text);
 
     QPalette palette;
     QColor brushCorlor;


### PR DESCRIPTION
Center text horizontally in RecognizeDialog paint event

Adjust the x-coordinate calculation in `RecognizeDialog::paintEvent` to properly center the text within the dialog. The previous calculation did not account for the full width of the text, resulting in misalignment. This change ensures the text is centered correctly.

pms: BUG-307573

## Summary by Sourcery

Bug Fixes:
- Correct x-coordinate computation in RecognizeDialog::paintEvent to center text horizontally and prevent truncation.