### PR TITLE
fix: incorrect way to load translations

### DIFF
--- a/dde-bluetooth-dialog/src/main.cpp
+++ b/dde-bluetooth-dialog/src/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
     app.setOrganizationName("deepin");
     app.setApplicationName("dde-bluetooth-dialog");
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         app.installTranslator(&translator);
     }
 

--- a/dde-hints-dialog/src/main.cpp
+++ b/dde-hints-dialog/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
     a.setQuitOnLastWindowClosed(true);
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         a.installTranslator(&translator);
     }
 

--- a/dde-license-dialog/src/main.cpp
+++ b/dde-license-dialog/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
     DApplication a(argc, argv);
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         a.installTranslator(&translator);
     }
 

--- a/dde-lowpower/src/main.cpp
+++ b/dde-lowpower/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         a.installTranslator(&translator);
     }
 

--- a/dde-osd/src/main.cpp
+++ b/dde-osd/src/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     QAccessible::installFactory(accessibleFactory);
 
     QTranslator translator;
-    translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name());
+    translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations");
     app->installTranslator(&translator);
 
     QStringList args = app->arguments();

--- a/dde-suspend-dialog/src/main.cpp
+++ b/dde-suspend-dialog/src/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
     app.setApplicationName("dde-suspend-dialog");
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         app.installTranslator(&translator);
     }
 

--- a/dde-touchscreen-dialog/src/main.cpp
+++ b/dde-touchscreen-dialog/src/main.cpp
@@ -25,8 +25,7 @@ int main(int argc, char *argv[])
     app.setQuitOnLastWindowClosed(true);
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" +
-                    QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         app.installTranslator(&translator);
     }
 

--- a/dde-warning-dialog/src/main.cpp
+++ b/dde-warning-dialog/src/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
     a.setQuitOnLastWindowClosed(true);
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         a.installTranslator(&translator);
     }
 

--- a/dde-welcome/src/main.cpp
+++ b/dde-welcome/src/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
     DLogManager::registerFileAppender();
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         app.installTranslator(&translator);
     }
 

--- a/dde-wm-chooser/src/main.cpp
+++ b/dde-wm-chooser/src/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     a.setApplicationName("deepin-wm-chooser");
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         a.installTranslator(&translator);
     }
 

--- a/dmemory-warning-dialog/src/main.cpp
+++ b/dmemory-warning-dialog/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *args[])
         return -1;
 
     QTranslator translator;
-    translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name());
+    translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations");
     dapp.installTranslator(&translator);
 
 #ifdef QT_DEBUG

--- a/dnetwork-secret-dialog/src/main.cpp
+++ b/dnetwork-secret-dialog/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     DLogManager::registerFileAppender();
 
     QTranslator translator;
-    if (translator.load("/usr/share/dde-session-ui/translations/dde-session-ui_" + QLocale::system().name())) {
+    if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         app.installTranslator(&translator);
         app.loadTranslator();
     }


### PR DESCRIPTION
当前的加载方式会导致不完全匹配的翻译资源无法被恰当加载.

Log:

## Summary by Sourcery

Use Qt’s QTranslator.load(locale, prefix, separator, directory) overload across all dialog applications to correctly load translation files and support fallback matching instead of manual path construction.

Bug Fixes:
- Fix incorrect loading of translation resources by replacing hard-coded file path concatenation with the QTranslator.load(locale, prefix, separator, directory) overload in all dialogs.

Enhancements:
- Unify translation loading approach across multiple dialog modules for consistent behavior.