### PR TITLE
chore: bump version to 6.0.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-session-ui (6.0.30) unstable; urgency=medium
+
+  * chore: remove regional variants for es language
+  * fix(license): reuse lint
+  * fix: incorrect way to load translations
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Mon, 23 Jun 2025 17:16:44 +0800
+
 dde-session-ui (6.0.29) unstable; urgency=medium
 
   * fix: Display name truncation


### PR DESCRIPTION
update changelog to 6.0.30