### PR TITLE
refactor: move security flags to debian/rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,6 @@ option(DISABLE_SYS_UPDATE "disable sys update" OFF)
 set(QT_VERSION_MAJOR 6)
 set(DTK_VERSION_MAJOR 6)
 
-# 增加安全编译参数
-ADD_DEFINITIONS("-fstack-protector-strong -D_FORTITY_SOURCE=1 -z noexecstack -pie -fPIC -z lazy")
-
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-fsanitize=address)
     add_link_options(-fsanitize=address)

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,11 @@ export QT_SELECT=5
 include /usr/share/dpkg/default.mk
 SYSTYPE=Desktop
 SYSTYPE=$(shell cat /etc/deepin-version | grep Type= | awk -F'=' '{print $$2}')
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
1. Removed hardcoded security compilation flags from CMakeLists.txt
2. Added standardized Debian hardening flags in debian/rules
3. Flags now follow Debian packaging best practices
4. Includes additional security measures like RELRO and immediate binding
5. Maintains same security level while being more maintainable

refactor: 将安全编译参数移至 debian/rules

1. 从 CMakeLists.txt 中移除硬编码的安全编译参数
2. 在 debian/rules 中添加标准化的 Debian 加固标志
3. 标志现在遵循 Debian 打包最佳实践
4. 包含额外的安全措施如 RELRO 和立即绑定
5. 在保持相同安全级别的同时提高可维护性

## Summary by Sourcery

Centralize compilation hardening flags in the Debian packaging rules and remove them from CMakeLists to follow Debian best practices and improve maintainability.

Enhancements:
- Include additional security hardening measures such as RELRO and immediate symbol binding.
- Maintain the same security level while shifting flag management to packaging scripts.

Build:
- Remove hardcoded security flags from CMakeLists.txt.
- Add standardized Debian hardening flags in debian/rules.