### PR TITLE
chore: bump version to 6.0.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-ui (6.0.31) unstable; urgency=medium
+
+  * refactor: move security flags to debian/rules
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 19:55:35 +0800
+
 dde-session-ui (6.0.30) unstable; urgency=medium
 
   * chore: remove regional variants for es language


### PR DESCRIPTION
update changelog to 6.0.31

## Summary by Sourcery

Chores:
- Bump version to 6.0.31 and update the Debian changelog.