### PR TITLE
fix: Incorrect screen indication display

### DIFF
--- a/dde-touchscreen-dialog/src/monitorindicator.cpp
+++ b/dde-touchscreen-dialog/src/monitorindicator.cpp
@@ -14,33 +14,31 @@ MonitorIndicator::MonitorIndicator(QWidget *parent)
     : QFrame(parent)
 {
     setAccessibleName("MonitorIndicator");
-    setWindowFlags(Qt::SplashScreen | Qt::X11BypassWindowManagerHint);
-    setStyleSheet("background-color: #2ca7f8;");
+    setWindowFlags(Qt::SplashScreen | Qt::X11BypassWindowManagerHint | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_ShowWithoutActivating);
+}
+
+void MonitorIndicator::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event)
+    
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+    
+    // 设置蓝色边框
+    QPen pen(QColor("#2ca7f8"));
+    pen.setWidth(10); // 设置边框宽度
+    painter.setPen(pen);
+    
+    // 绘制矩形边框，留出一些边距
+    QRect borderRect = rect().adjusted(5, 5, -5, -5);
+    painter.drawRect(borderRect);
 }
 
 void MonitorIndicator::resizeEvent(QResizeEvent *e)
 {
     QFrame::resizeEvent(e);
-
-    Display* display = XOpenDisplay(nullptr);
-    if (!display) {
-        qWarning() << "XOpenDisplay failed";
-        return;
-    }
-
-    XRectangle rectangle;
-    rectangle.x = 0;
-    rectangle.y = 0;
-    rectangle.width = static_cast<ushort>(e->size().width());
-    rectangle.height = static_cast<ushort>(e->size().height());
-
-    // need to restore the cut area, if not,cut out will be repeated.
-    XShapeCombineRectangles(display, winId(), ShapeBounding, 0, 0, &rectangle, 1, ShapeSet, YXBanded);
-
-    rectangle.x = 10;
-    rectangle.y = 10;
-    rectangle.width = static_cast<ushort>(e->size().width()) - 20;
-    rectangle.height = static_cast<ushort>(e->size().height()) - 20;
-
-    XShapeCombineRectangles(display, winId(), ShapeBounding, 0, 0, &rectangle, 1, ShapeSubtract, YXBanded);
+    update(); // 触发重绘
 }

--- a/dde-touchscreen-dialog/src/monitorindicator.h
+++ b/dde-touchscreen-dialog/src/monitorindicator.h
@@ -19,6 +19,7 @@ public:
     explicit MonitorIndicator(QWidget *parent = 0);
 
 protected:
+    void paintEvent(QPaintEvent *event) override;
     void resizeEvent(QResizeEvent *e);
 };
 

--- a/dde-touchscreen-dialog/src/touchscreensetting.cpp
+++ b/dde-touchscreen-dialog/src/touchscreensetting.cpp
@@ -115,9 +115,21 @@ bool TouchscreenSetting::monitorsIsIntersect() const
 
 void TouchscreenSetting::markDisplay(int index)
 {
-    m_monitorIndicator->setGeometry(QRect(m_monitors[index]->x(), m_monitors[index]->y(), m_monitors[index]->width(), m_monitors[0]->height()));
+    // 考虑设备像素比，确保示意框大小与实际显示器大小一致
+    const auto ratio = qApp->devicePixelRatio();
+    QRect displayRect(m_monitors[index]->x(), m_monitors[index]->y(), 
+                     m_monitors[index]->width(), m_monitors[index]->height());
+    
+    // 将物理像素转换为逻辑像素
+    displayRect = QRect(displayRect.topLeft(), displayRect.size() / ratio);
+    
+    // 先隐藏窗口，设置几何形状，再显示，避免动画效果
+    m_monitorIndicator->hide();
+    m_monitorIndicator->setGeometry(displayRect);
     m_monitorIndicator->show();
-    QTimer::singleShot(300, this, [ = ] {
+    
+    // 设置自动隐藏
+    QTimer::singleShot(1000, this, [ = ] {
         m_monitorIndicator->hide();
     });
 }


### PR DESCRIPTION
Improves dde-touchscreen-dialog UI and DPI handling

This commit addresses DPI scaling issues and enhances the user interface of the dde-touchscreen-dialog.

- Fixes an issue where the monitor indicator size was inconsistent with the actual display size on high-DPI displays by incorporating device pixel ratio handling.
- Improves the visual clarity of the monitor selection indicator by changing it to a hollow transparent design with a blue border.

These changes result in a more polished and functional touchscreen configuration experience, especially on high-resolution displays.

pms: BUG-318697

## Summary by Sourcery

Improve the touchscreen dialog’s monitor indicator by handling device pixel ratios correctly and redesigning its appearance for better clarity on high-DPI displays.

Bug Fixes:
- Fix inconsistent monitor indicator sizing on high-DPI displays by incorporating device pixel ratio handling.

Enhancements:
- Redesign the monitor indicator as a hollow transparent frame with a blue border and antialiasing.
- Use Qt frameless, translucent, on-top window flags and a custom paintEvent instead of XShape-based masking.
- Hide the indicator while updating its geometry and add an automatic 1-second auto-hide timer.