### PR TITLE
fix: Fix qt default translation not loading

### DIFF
--- a/dde-license-dialog/src/main.cpp
+++ b/dde-license-dialog/src/main.cpp
@@ -24,6 +24,8 @@ int main(int argc, char *argv[])
     qputenv("DSG_APP_ID", "org.deepin.dde.license-dialog");
     DApplication a(argc, argv);
 
+    a.loadTranslator();
+
     QTranslator translator;
     if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         a.installTranslator(&translator);


### PR DESCRIPTION
Fix qt default translation not loading

Log: Fix qt default translation not loading
pms: bug-290029

## Summary by Sourcery

Fix loading of the default Qt translations in dde-license-dialog by adding translators for qtbase and qt with proper lookup paths and fallback directories.

Bug Fixes:
- Load and install Qt base and Qt translations from the system locale using QLibraryInfo path and fallback directories

Enhancements:
- Log warnings when Qt base or Qt translations fail to load