### PR TITLE
fix: set DSG_APP_ID environment variable

### DIFF
--- a/dde-license-dialog/src/main.cpp
+++ b/dde-license-dialog/src/main.cpp
@@ -21,6 +21,7 @@ DGUI_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
+    qputenv("DSG_APP_ID", "org.deepin.dde.license-dialog");
     DApplication a(argc, argv);
 
     QTranslator translator;


### PR DESCRIPTION
Explicitly set DSG_APP_ID to "org.deepin.dde.license-dialog" at application startup
Prevents inheriting DSG_APP_ID from other processes which could cause incorrect configuration
Ensures the license dialog uses its own specific application settings

fix: 设置 DSG_APP_ID 环境变量

在应用程序启动时显式设置 DSG_APP_ID 为 "org.deepin.dde.license-dialog" 防止从其他进程继承 DSG_APP_ID，避免导致配置错误
确保许可证对话框使用其特定的应用程序设置

PMS: BUG-329943

## Summary by Sourcery

Bug Fixes:
- Prevent inheriting DSG_APP_ID by explicitly setting it to org.deepin.dde.license-dialog at application startup