### PR TITLE
chore: bump version to 6.0.33

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-ui (6.0.33) unstable; urgency=medium
+
+  * fix: Fix qt default translation not loading
+  * fix: set DSG_APP_ID environment variable
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 21 Aug 2025 19:47:22 +0800
+
 dde-session-ui (6.0.32) unstable; urgency=medium
 
   * fix: Incorrect screen indication display


### PR DESCRIPTION
update changelog to 6.0.33

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.0.33