### PR TITLE
chore: update changelog to 6.0.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-ui (6.0.39) unstable; urgency=medium
+
+  * fix(touchscreen-dialog): fix crash when monitor list changes
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 26 Mar 2026 19:40:14 +0800
+
 dde-session-ui (6.0.38) unstable; urgency=medium
 
   * fix(viewing): replace font metrics with document renderer


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.39

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.39
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.0.39 targeting master.