### PR TITLE
fix(license-dialog): optimize window blur effect and theme adaptation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ global_util/dbus/*.cpp
 global_util/dbus/*.h
 
 .cache
+obj-x86_64-linux-gnu/*

--- a/dde-license-dialog/src/content.cpp
+++ b/dde-license-dialog/src/content.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 #include <DSuggestButton>
 #include <DFontSizeManager>
 #include <DPalette>
+#include <DGuiApplicationHelper>
 
 #include <QScrollArea>
 #include <QPushButton>
@@ -67,13 +68,15 @@ Content::Content(QWidget *parent)
 
     layout->addWidget(m_languageBtn, 0, Qt::AlignHCenter);
 
-    m_scrollArea->setMinimumSize(468, 300);
+    m_scrollArea->setMinimumSize(390, 300);
     m_scrollArea->setWidgetResizable(true);
     m_scrollArea->setFrameStyle(QFrame::NoFrame);
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_scrollArea->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
     m_scrollArea->setContentsMargins(0, 0, 0, 0);
+    m_scrollArea->setStyleSheet("QScrollArea { background: transparent; }"
+                                "QScrollArea > QWidget > QWidget { background: transparent; }");
     QScroller::grabGesture(m_scrollArea->viewport(), QScroller::LeftMouseButtonGesture);
 
     QWidget *sourceWidget = new QWidget(this);
@@ -85,9 +88,8 @@ Content::Content(QWidget *parent)
     m_cancelBtn->setFixedHeight(36);
     m_acceptBtn->setFixedHeight(36);
 
-    DPalette pa = m_acceptBtn->palette();
-    pa.setColor(QPalette::ButtonText, pa.highlight().color());
-    m_acceptBtn->setPalette(pa);
+    updateAcceptBtnPalette();
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &Content::updateAcceptBtnPalette);
 
     m_source->setTextFormat(Qt::MarkdownText);
     m_source->setWordWrap(true);
@@ -286,4 +288,24 @@ void Content::updateWindowHeight()
     int contentHeight = static_cast<int>(doc.size().height());
     int minHeight = qBound(100, contentHeight, 491);
     m_scrollArea->setMinimumHeight(minHeight);
+}
+
+void Content::updateAcceptBtnPalette()
+{
+    const QString btnStyle = "QPushButton { background-color: rgba(0, 0, 0, 0.15); border: none; border-radius: 6px; }"
+                             "QPushButton:hover { background-color: rgba(0, 0, 0, 0.2); }"
+                             "QPushButton:pressed { background-color: rgba(0, 0, 0, 0.25); }";
+    m_cancelBtn->setStyleSheet(btnStyle);
+    m_acceptBtn->setStyleSheet(btnStyle);
+
+    DPalette pa = m_acceptBtn->palette();
+    QColor highlightColor = pa.highlight().color();
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
+        highlightColor.setAlphaF(0.7);
+    } else {
+        highlightColor.setAlphaF(0.6);
+    }
+    pa.setColor(QPalette::Disabled, QPalette::ButtonText, highlightColor);
+    pa.setColor(QPalette::Normal, QPalette::ButtonText, pa.highlight().color());
+    m_acceptBtn->setPalette(pa);
 }

--- a/dde-license-dialog/src/content.h
+++ b/dde-license-dialog/src/content.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -44,6 +44,7 @@ private:
     void updateLanguageBtn();
     void updateContent();
     void updateWindowHeight();
+    void updateAcceptBtnPalette();
 
 private:
     QScrollArea* m_scrollArea;

--- a/dde-license-dialog/src/main.cpp
+++ b/dde-license-dialog/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,7 @@
 
 #include <DApplication>
 #include <DGuiApplicationHelper>
+#include <DWidgetUtil>
 
 #include <QTranslator>
 #include <QCommandLineOption>
@@ -117,7 +118,7 @@ int main(int argc, char *argv[])
     checker.setOutputFormat(DAccessibilityChecker::FullFormat);
     checker.start();
 #endif
-    w.moveToCenter();
+    Dtk::Widget::moveToCenter(&w);
     w.show();
 
 

--- a/dde-license-dialog/src/mainwindow.cpp
+++ b/dde-license-dialog/src/mainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,10 +13,13 @@
 #include <DFontSizeManager>
 DTK_USE_NAMESPACE
 
+const int DefaultRadius = 8;
+
 MainWindow::MainWindow(QWidget *parent)
-    : DAbstractDialog(false, parent)
+    : DBlurEffectWidget(parent)
     , m_title(new QLabel)
     , m_content(new Content)
+    , m_handle(new DPlatformWindowHandle(this))
 {
     auto envType = qEnvironmentVariable("XDG_SESSION_TYPE");
     bool bWayland = envType.contains("wayland");
@@ -27,11 +30,23 @@ MainWindow::MainWindow(QWidget *parent)
     }
 
     setAccessibleName("MainWindow");
+
+    setAttribute(Qt::WA_TranslucentBackground);
+
+    setBlendMode(DBlurEffectWidget::BehindWindowBlend);
+    setMaskColor(DBlurEffectWidget::AutoColor);
+
+    m_handle->setEnableBlurWindow(true);
+    m_handle->setTranslucentBackground(true);
+    m_handle->setShadowOffset(QPoint(0, 0));
+    m_handle->setBorderWidth(0);
+    m_handle->setWindowRadius(DefaultRadius);
+
     m_title->setObjectName("TitleLabel");
     m_title->setAccessibleName("TitleLabel");
     QWidget *widget = new QWidget(this);
     widget->setAccessibleName("MainWidget");
-    widget->setFixedSize(500, 40);
+    widget->setFixedSize(430, 40);
 
     btnclose = new DIconButton(QStyle::SP_TitleBarCloseButton, this);
     btnclose->setAccessibleName("CloseBtn");
@@ -91,7 +106,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 void MainWindow::resizeEvent(QResizeEvent *event)
 {
-    DAbstractDialog::resizeEvent(event);
+    DBlurEffectWidget::resizeEvent(event);
     if (btnclose) {
         const QSize sz = btnclose->sizeHint();
         btnclose->move(width() - sz.width(), 0);

--- a/dde-license-dialog/src/mainwindow.h
+++ b/dde-license-dialog/src/mainwindow.h
@@ -1,18 +1,19 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-#include <dabstractdialog.h>
+#include <DBlurEffectWidget>
 #include <DIconButton>
+#include <DPlatformWindowHandle>
 
 DWIDGET_USE_NAMESPACE
 
 class Content;
 class QLabel;
-class MainWindow : public DAbstractDialog
+class MainWindow : public DBlurEffectWidget
 {
     Q_OBJECT
 
@@ -43,7 +44,8 @@ private:
 
     DIconButton *btnclose;
     DIconButton *m_leftIconBtn;
-    const int windowFixedWidth = 520;
+    DPlatformWindowHandle *m_handle;
+    const int windowFixedWidth = 430;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Replace DAbstractDialog with DBlurEffectWidget to implement window blur effect. Add dynamic theme adaptation for button styling. Optimize window size and layout for better visual consistency.

使用DBlurEffectWidget替代DAbstractDialog实现窗口模糊效果。添加按钮
样式的动态主题适配功能。优化窗口尺寸和布局以提升视觉一致性。

Log: 优化许可协议对话框的模糊效果和主题适配
PMS: BUG-349395
Influence: 许可协议对话框现在支持模糊背景效果，按钮样式会根据主题
自动调整，提供更好的视觉体验和主题一致性。

## Summary by Sourcery

Switch the license dialog window to use a blur-effect widget with adjusted sizing while improving button appearance and theme responsiveness.

New Features:
- Add dynamic theme-based styling for dialog action buttons so their appearance adapts to light and dark modes.
- Enable a translucent blurred background for the license dialog window via a blur-effect widget and platform window handle configuration.

Enhancements:
- Adjust the license dialog window and scroll area dimensions and transparency for better visual balance and consistency across themes.
- Center the main window using the Dtk widget utility helper instead of the previous method.
- Update SPDX copyright year ranges across modified files.