### PR TITLE
feat: add cancel button state parameter for bluetooth dialog

### DIFF
--- a/dde-bluetooth-dialog/src/main.cpp
+++ b/dde-bluetooth-dialog/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2016 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2016 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,6 +19,7 @@ DCORE_USE_NAMESPACE
 const int PingCode = 1;
 const int DevicePath = 2;
 const int PingTime = 3;
+const int CancelBtnState = 4;
 
 int main(int argc, char *argv[])
 {
@@ -35,9 +36,14 @@ int main(int argc, char *argv[])
         qDebug() << "number of parameters must be greater than 3";
         return -1;
     }
-    qDebug() << "PingCode:" << arguslist[PingCode] << " Device Path:" << arguslist[DevicePath] << "Ping Time:" + arguslist[PingTime];
+    auto cancelable = true;
+    if (arguslist.size() >= 5) {
+        cancelable = arguslist[CancelBtnState] == "true";
+    }
+    qDebug() << "PingCode:" << arguslist[PingCode] << " Device Path:" << arguslist[DevicePath] << "Ping Time:" + arguslist[PingTime]
+             << "isCancelBtnShown:" << cancelable;
 
-    PinCodeDialog dialog(arguslist[PingCode], arguslist[DevicePath], arguslist[PingTime], true);
+    PinCodeDialog dialog(arguslist[PingCode], arguslist[DevicePath], arguslist[PingTime], cancelable);
 #if (defined QT_DEBUG) && (defined CHECK_ACCESSIBLENAME)
     AccessibilityCheckerEx checker;
     checker.setOutputFormat(DAccessibilityChecker::FullFormat);


### PR DESCRIPTION
1. Add new CancelBtnState constant (index 4) for command line argument parsing
2. Introduce cancelable variable to control cancel button visibility
3. Read optional 5th parameter to determine cancel button state
4. Default cancelable to true when 5th parameter is not provided
5. Pass cancelable state to PinCodeDialog constructor instead of hardcoded true
6. Update debug output to include isCancelBtnShown information

Log: Added cancel button visibility parameter for Bluetooth pairing dialog

Influence:
1. Test Bluetooth pairing dialog with cancel button enabled (pass "true" as 5th argument)
2. Test Bluetooth pairing dialog with cancel button disabled (pass "false" as 5th argument)
3. Verify backward compatibility when only 4 arguments are provided (should default to showing cancel button)
4. Test dialog behavior during pairing process with different cancel button states
5. Verify command line argument parsing with various parameter combinations

feat: 新增蓝牙弹窗取消按钮状态参数

1. 添加新的 CancelBtnState 常量（索引 4）用于命令行参数解析
2. 引入 cancelable 变量控制取消按钮的可见性
3. 读取可选的第 5 个参数来确定取消按钮状态
4. 当未提供第 5 个参数时，cancelable 默认为 true
5. 将 cancelable 状态传递给 PinCodeDialog 构造函数，替代硬编码的 true
6. 更新调试输出以包含 isCancelBtnShown 信息

Log: 新增蓝牙配对弹窗取消按钮可见性参数

Influence:
1. 测试启用取消按钮的蓝牙配对弹窗（第 5 个参数传 "true"）
2. 测试禁用取消按钮的蓝牙配对弹窗（第 5 个参数传 "false"）
3. 验证仅提供 4 个参数时的向后兼容性（应默认显示取消按钮）
4. 测试不同取消按钮状态下配对过程中的弹窗行为
5. 验证各种参数组合下的命令行参数解析

PMS: BUG-343047
Change-Id: I617b0b24a0709f4c9395879a9b17df69b705cf60

## Summary by Sourcery

Add support for controlling the Bluetooth PIN code dialog’s cancel button visibility via an optional command line parameter and propagate this state into the dialog.

New Features:
- Introduce an optional command line parameter to specify whether the Bluetooth pairing dialog’s cancel button is shown.

Enhancements:
- Log the resolved cancel button visibility state for the Bluetooth pairing dialog in debug output.