### PR TITLE
chore: update changelog to 6.0.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session-ui (6.0.41) unstable; urgency=medium
+
+  * feat: add cancel button state parameter for bluetooth dialog
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:49:05 +0800
+
 dde-session-ui (6.0.40) unstable; urgency=medium
 
   * fix(license-dialog): optimize window blur effect and theme


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.41

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.41
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.0.41 targeting master.