### PR TITLE
chore: update changelog to 6.0.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-ui (6.0.42) unstable; urgency=medium
+
+  * i18n: [dde-session-ui] Updates for project Deepin Desktop
+    Environment (#425)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 08 May 2026 15:03:28 +0800
+
 dde-session-ui (6.0.41) unstable; urgency=medium
 
   * feat: add cancel button state parameter for bluetooth dialog


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.42

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.42
- 目标分支: master
