### PR TITLE
Fix: When the control center opens the disclaimer box, extra icon lab…

### DIFF
--- a/dde-license-dialog/src/mainwindow.cpp
+++ b/dde-license-dialog/src/mainwindow.cpp
@@ -26,7 +26,7 @@ MainWindow::MainWindow(QWidget *parent)
     if (bWayland) {
         setWindowFlags(windowFlags() | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
     } else {
-        setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+        setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
     }
 
     setAccessibleName("MainWindow");


### PR DESCRIPTION
…els are displayed on the taskbar.

In X11 mode, add the Qt::Tool flag to the window's flags and disable the taskbar display.

Log: Fixed the issue of extra icons displayed in the taskbar under X11 by adding the Qt::Tool flag. PMS:

fix: 控制中心打开免责声明框时任务栏展示多余图标标签

在X11模式下为窗口标志添加Qt::Tool标志，过滤任务栏显示

Log: 通过添加Qt::Tool标志修复X11下任务栏显示多余标志

PMS: BUG-359493

## Summary by Sourcery

Bug Fixes:
- Ensure the license dialog in X11 uses a tool-style window so it no longer appears as an extra icon in the taskbar.