### PR TITLE
fix: fix ODR violation of PaintWidget by wrapping it in anonymous nam…

### DIFF
--- a/dde-osd/tests/ut_audioprovider.cpp
+++ b/dde-osd/tests/ut_audioprovider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,7 @@ class UT_AudioProvider : public testing::Test
 
 };
 
+namespace {
 class PaintWidget : public QWidget
 {
 
@@ -39,6 +40,7 @@ public:
 public:
     AudioProvider *m_provider;
 };
+}  // namespace
 
 
 TEST_F(UT_AudioProvider, coverageTest)

--- a/dde-osd/tests/ut_brightnessprovider.cpp
+++ b/dde-osd/tests/ut_brightnessprovider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,7 @@ class UT_BrightnessProvider : public testing::Test
 
 };
 
+namespace {
 class PaintWidget : public QWidget
 {
 
@@ -39,6 +40,7 @@ public:
 public:
     BrightnessProvider *m_provider;
 };
+}  // namespace
 
 
 TEST_F(UT_BrightnessProvider, coverageTest)

--- a/dde-osd/tests/ut_common.cpp
+++ b/dde-osd/tests/ut_common.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,7 @@ class UT_Common : public testing::Test
 
 };
 
+namespace {
 class PaintWidget : public QWidget
 {
 
@@ -36,6 +37,7 @@ public:
         DrawHelper::DrawBackground(&painter, option);
     }
 };
+}  // namespace
 
 TEST_F(UT_Common, coverageTest)
 {

--- a/dde-osd/tests/ut_displaymodeprovider.cpp
+++ b/dde-osd/tests/ut_displaymodeprovider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,7 @@ class UT_DisplayModeProvider : public testing::Test
 
 };
 
+namespace {
 class PaintWidget : public QWidget
 {
 
@@ -40,6 +41,7 @@ public:
 public:
     DisplayModeProvider *m_provider;
 };
+}  // namespace
 
 TEST_F(UT_DisplayModeProvider, coverageTest)
 {

--- a/dde-osd/tests/ut_kblayoutprovider.cpp
+++ b/dde-osd/tests/ut_kblayoutprovider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,7 @@ class UT_KBLayoutProvider : public testing::Test
 
 };
 
+namespace {
 class PaintWidget : public QWidget
 {
 
@@ -38,6 +39,7 @@ public:
 public:
     KBLayoutProvider *m_provider;
 };
+}  // namespace
 
 TEST_F(UT_KBLayoutProvider, coverageTest)
 {

--- a/dde-osd/tests/ut_osdprovider.cpp
+++ b/dde-osd/tests/ut_osdprovider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,7 @@ class UT_OSDProvider : public testing::Test
 
 };
 
+namespace {
 class PaintWidget : public QWidget
 {
 
@@ -38,6 +39,7 @@ public:
 public:
     OSDProvider *m_provider;
 };
+}  // namespace
 
 TEST_F(UT_OSDProvider, coverageTest)
 {


### PR DESCRIPTION
…espace

Wrap PaintWidget class in `namespace { ... }` across 6 test files to comply with the C++ One Definition Rule, eliminating cppcheck ctuOneDefinitionRuleViolation errors.

fix: 用匿名命名空间修复 PaintWidget 的 ODR 违规

在 6 个测试文件中将 PaintWidget 类放入匿名命名空间，遵循 C++ 单一定义
规则，消除 cppcheck 报告的 CTU ODR 违规错误。

Log: Fix ODR violation of PaintWidget in test files by wrapping with anonymous namespace

PMS: BUG-366487