### PR TITLE
chore: update changelog to 6.0.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session-ui (6.0.44) unstable; urgency=medium
+
+  * fix: fix ODR violation of PaintWidget by wrapping it in anonymous
+    namespace
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:17:21 +0800
+
 dde-session-ui (6.0.43) unstable; urgency=medium
 
   * Fix: When the control center opens the disclaimer box, extra icon


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.44

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.44
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entry to document version 6.0.44 targeting master.