### PR TITLE
feat: set desktop file names and install desktop entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -100,3 +100,7 @@ file(GLOB TS_FILES "translations/*.ts")
 qt_add_translation(QM_FILES ${TS_FILES})
 add_custom_target(dde-session-ui_language ALL DEPENDS ${QM_FILES})
 install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/translations)
+
+#----------------------------install desktop files and icons--------------------
+file(GLOB DESKTOP_FILES ${CMAKE_SOURCE_DIR}/misc/applications/*.desktop)
+install(FILES ${DESKTOP_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -82,7 +82,7 @@ SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 [[annotations]]
-path = ["dde-osd/files/dde-osd.desktop", "deepin-login-reminder/deepin-login-reminder.desktop", "deepin-login-reminder/dconf/org.deepin.login-reminder.json"]
+path = ["dde-osd/files/dde-osd.desktop", "deepin-login-reminder/deepin-login-reminder.desktop", "deepin-login-reminder/dconf/org.deepin.login-reminder.json", "misc/applications/*.desktop"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
 SPDX-License-Identifier = "GPL-3.0-or-later"

--- a/dde-blackwidget/src/main.cpp
+++ b/dde-blackwidget/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -64,6 +64,9 @@ int main(int argc, char *argv[])
     }
 
     QApplication a(argc, argv);
+    a.setOrganizationName("deepin");
+    a.setApplicationName("dde-blackwidget");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.blackwidget"));
 
     DCORE_USE_NAMESPACE::Dtk::Core::DLogManager::registerConsoleAppender();
 

--- a/dde-bluetooth-dialog/src/main.cpp
+++ b/dde-bluetooth-dialog/src/main.cpp
@@ -26,6 +26,7 @@ int main(int argc, char *argv[])
     DApplication app(argc, argv);
     app.setOrganizationName("deepin");
     app.setApplicationName("dde-bluetooth-dialog");
+    app.setDesktopFileName(QStringLiteral("org.deepin.dde.bluetooth-dialog"));
     QTranslator translator;
     if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {
         app.installTranslator(&translator);

--- a/dde-hints-dialog/src/main.cpp
+++ b/dde-hints-dialog/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,7 +20,9 @@ const int HINT_CONTENT = 2;
 int main(int argc, char *argv[])
 {
     DApplication a(argc, argv);
+    a.setOrganizationName("deepin");
     a.setApplicationName("dde-hints-dialog");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.hints-dialog"));
     a.setApplicationVersion("1.0");
     a.setQuitOnLastWindowClosed(true);
 

--- a/dde-license-dialog/src/main.cpp
+++ b/dde-license-dialog/src/main.cpp
@@ -24,6 +24,9 @@ int main(int argc, char *argv[])
 {
     qputenv("DSG_APP_ID", "org.deepin.dde.license-dialog");
     DApplication a(argc, argv);
+    a.setOrganizationName("deepin");
+    a.setApplicationName("dde-license-dialog");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.license-dialog"));
 
     a.loadTranslator();
 

--- a/dde-lowpower/src/main.cpp
+++ b/dde-lowpower/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,6 +28,9 @@ DWIDGET_USE_NAMESPACE
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+    a.setOrganizationName("deepin");
+    a.setApplicationName("dde-lowpower");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.lowpower"));
 
     QTranslator translator;
     if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {

--- a/dde-pixmix/src/main.cpp
+++ b/dde-pixmix/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -74,6 +74,7 @@ int main(int argc, char *argv[])
 
     a.setOrganizationName("deepin");
     a.setApplicationName("dde-pixmix");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.pixmix"));
 
     DLogManager::registerConsoleAppender();
     DLogManager::registerJournalAppender();

--- a/dde-suspend-dialog/src/main.cpp
+++ b/dde-suspend-dialog/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2016 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2016 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,7 @@ int main(int argc, char *argv[])
     DApplication app(argc, argv);
     app.setOrganizationName("deepin");
     app.setApplicationName("dde-suspend-dialog");
+    app.setDesktopFileName(QStringLiteral("org.deepin.dde.suspend-dialog"));
 
     QTranslator translator;
     if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {

--- a/dde-touchscreen-dialog/src/main.cpp
+++ b/dde-touchscreen-dialog/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,9 @@ using namespace org::deepin::dde;
 int main(int argc, char *argv[])
 {
     DApplication app(argc, argv);
+    app.setOrganizationName("deepin");
+    app.setApplicationName("dde-touchscreen-dialog");
+    app.setDesktopFileName(QStringLiteral("org.deepin.dde.touchscreen-dialog"));
     app.setQuitOnLastWindowClosed(false);
     app.setQuitOnLastWindowClosed(true);
 
@@ -49,7 +52,15 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    TouchscreenSetting s(posArguments.first());
+    // 如果该触摸设备已被关联到屏幕，则不再弹出选择窗口
+    const QString &touchUUID = posArguments.first();
+    const auto touchMap = display.touchMap();
+    if (touchMap.contains(touchUUID)) {
+        qDebug() << "touchscreen already associated:" << touchUUID << "->" << touchMap[touchUUID];
+        return 0;
+    }
+
+    TouchscreenSetting s(touchUUID);
 #if (defined QT_DEBUG) && (defined CHECK_ACCESSIBLENAME)
     AccessibilityCheckerEx checker;
     checker.setOutputFormat(DAccessibilityChecker::FullFormat);

--- a/dde-warning-dialog/src/main.cpp
+++ b/dde-warning-dialog/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -29,7 +29,9 @@ int main(int argc, char *argv[])
     }
 
     DApplication a(argc, argv);
+    a.setOrganizationName("deepin");
     a.setApplicationName("dde-warning-dialog");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.warning-dialog"));
     a.setApplicationVersion("1.0");
     a.setQuitOnLastWindowClosed(true);
 

--- a/dde-welcome/src/main.cpp
+++ b/dde-welcome/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,6 +25,7 @@ int main(int argc, char *argv[])
     DApplication app(argc, argv);
     app.setOrganizationName("deepin");
     app.setApplicationName("dde-welcome");
+    app.setDesktopFileName(QStringLiteral("org.deepin.dde.welcome"));
 
     if (!app.setSingleInstance(app.applicationName(), DApplication::UserScope))
         return -1;

--- a/dde-wm-chooser/src/main.cpp
+++ b/dde-wm-chooser/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -47,7 +47,9 @@ void selectNormalModel(QString qPath)
 int main(int argc, char *argv[])
 {
     DApplication a(argc, argv);
+    a.setOrganizationName("deepin");
     a.setApplicationName("deepin-wm-chooser");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.wm-chooser"));
 
     QTranslator translator;
     if (translator.load(QLocale::system(), "dde-session-ui", "_", "/usr/share/dde-session-ui/translations")) {

--- a/misc/applications/org.deepin.dde.blackwidget.desktop
+++ b/misc/applications/org.deepin.dde.blackwidget.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Black Widget
+Comment=Deepin black screen overlay
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.bluetooth-dialog.desktop
+++ b/misc/applications/org.deepin.dde.bluetooth-dialog.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Bluetooth Dialog
+Comment=Deepin Bluetooth pairing dialog
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.hints-dialog.desktop
+++ b/misc/applications/org.deepin.dde.hints-dialog.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Hints Dialog
+Comment=Deepin hints dialog
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.license-dialog.desktop
+++ b/misc/applications/org.deepin.dde.license-dialog.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin License Dialog
+Comment=Deepin license agreement dialog
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.lowpower.desktop
+++ b/misc/applications/org.deepin.dde.lowpower.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Low Power
+Comment=Deepin low power overlay
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.pixmix.desktop
+++ b/misc/applications/org.deepin.dde.pixmix.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Pixmix
+Comment=Deepin image color processing tool
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.reset-password-dialog.desktop
+++ b/misc/applications/org.deepin.dde.reset-password-dialog.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Reset Password Dialog
+Comment=Deepin password reset dialog
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.suspend-dialog.desktop
+++ b/misc/applications/org.deepin.dde.suspend-dialog.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Suspend Dialog
+Comment=Deepin suspend confirmation dialog
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.touchscreen-dialog.desktop
+++ b/misc/applications/org.deepin.dde.touchscreen-dialog.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Touchscreen Dialog
+Comment=Deepin touchscreen association dialog
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.warning-dialog.desktop
+++ b/misc/applications/org.deepin.dde.warning-dialog.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Warning Dialog
+Comment=Deepin warning dialog
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.welcome.desktop
+++ b/misc/applications/org.deepin.dde.welcome.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin Welcome
+Comment=Deepin welcome screen
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/misc/applications/org.deepin.dde.wm-chooser.desktop
+++ b/misc/applications/org.deepin.dde.wm-chooser.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Deepin WM Chooser
+Comment=Deepin window manager chooser
+Icon=deepin-dde
+Exec=/bin/false
+TryExec=/bin/false
+NoDisplay=true
+Terminal=false
+StartupNotify=false
+Categories=System;

--- a/reset-password-dialog/main.cpp
+++ b/reset-password-dialog/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2016 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2016 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,6 +24,8 @@ int main(int argc, char *argv[])
     DApplication a(argc, argv);
     a.setQuitOnLastWindowClosed(true);
     a.setOrganizationName("deepin");
+    a.setApplicationName("reset-password-dialog");
+    a.setDesktopFileName(QStringLiteral("org.deepin.dde.reset-password-dialog"));
 
     QCommandLineParser parser;
     parser.addHelpOption();


### PR DESCRIPTION
1. Add org.deepin.dde.* desktop files for all dde-session-ui
applications
2. Set DesktopFileName property in all application main.cpp files
3. Set proper application names and organization names consistently
4. Install desktop files to share/applications directory via CMake
5. Update copyright years from 2023 to 2026 across all files
6. Add optimization to skip touchscreen dialog if device already
associated
7. Ensure consistent application metadata for session UI components

Log: Added desktop entry files and enabled proper installation for dde-
session-ui applications

Influence:
1. Verify all desktop files are installed in /usr/share/applications/
2. Test each application starts correctly via its desktop entry
3. Confirm application name and desktop file name consistency
4. Verify touchscreen dialog skips when device already associated
5. Check copyright header update does not affect functionality
6. Test reset-password-dialog with new desktop file name setting

feat: 为所有dde-session-ui应用设置桌面文件名并安装桌面入口文件

1. 为所有dde-session-ui应用程序添加org.deepin.dde.*桌面文件
2. 在所有应用程序的main.cpp中设置DesktopFileName属性
3. 统一设置正确的应用程序名称和组织名称
4. 通过CMake将桌面文件安装到share/applications目录
5. 将所有文件的版权年份从2023更新至2026
6. 优化触摸屏对话框，若设备已关联则跳过显示
7. 确保会话UI组件的应用程序元数据一致性

Log: 新增dde-session-ui应用的桌面入口文件并启用安装

Influence:
1. 验证所有桌面文件已安装至/usr/share/applications/
2. 测试每个应用程序通过桌面文件正确启动
3. 确认应用程序名称和桌面文件名称的一致性
4. 验证触摸屏对话框在设备已关联时跳过显示
5. 检查版权头更新不影响功能
6. 使用新的桌面文件名设置测试重置密码对话框

PMS: BUG-366057

## Summary by Sourcery

Add desktop entry integration and metadata normalization for dde-session-ui applications, including a small behavioral optimization in the touchscreen dialog.

New Features:
- Provide org.deepin.dde.* desktop entry files for all dde-session-ui components and install them to the system applications directory via CMake.

Enhancements:
- Set consistent organization name, application name, and desktop file name metadata across all dde-session-ui application entry points.
- Skip showing the touchscreen selection dialog when the target device is already associated to a display.
- Update SPDX copyright year ranges to 2026 across affected source and build files.

Build:
- Extend the CMake configuration to install all desktop files from misc/applications into the standard data applications directory.