### PR TITLE
chore: update changelog to 6.0.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-session-ui (6.0.45) unstable; urgency=medium
+
+  * feat: set desktop file names and install desktop entries
+  * chore: Sync by
+    https://github.com/linuxdeepin/.github/commit/88706fa723e3771211cb07
+    81d3d97fd4a6cd2a68
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 24 Jun 2026 15:34:35 +0800
+
 dde-session-ui (6.0.44) unstable; urgency=medium
 
   * fix: fix ODR violation of PaintWidget by wrapping it in anonymous


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.45

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.45
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release 6.0.45 in debian/changelog.