### PR TITLE
fix: show touchscreen dialog on init

### DIFF
--- a/dde-touchscreen-dialog/src/main.cpp
+++ b/dde-touchscreen-dialog/src/main.cpp
@@ -52,15 +52,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    // 如果该触摸设备已被关联到屏幕，则不再弹出选择窗口
-    const QString &touchUUID = posArguments.first();
-    const auto touchMap = display.touchMap();
-    if (touchMap.contains(touchUUID)) {
-        qDebug() << "touchscreen already associated:" << touchUUID << "->" << touchMap[touchUUID];
-        return 0;
-    }
-
-    TouchscreenSetting s(touchUUID);
+    TouchscreenSetting s(posArguments.first());
 #if (defined QT_DEBUG) && (defined CHECK_ACCESSIBLENAME)
     AccessibilityCheckerEx checker;
     checker.setOutputFormat(DAccessibilityChecker::FullFormat);

--- a/debian/rules
+++ b/debian/rules
@@ -6,8 +6,6 @@
 export QT_SELECT=5
 
 include /usr/share/dpkg/default.mk
-SYSTYPE=Desktop
-SYSTYPE=$(shell cat /etc/deepin-version | grep Type= | awk -F'=' '{print $$2}')
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_CFLAGS_MAINT_APPEND = -Wall
 export DEB_CXXFLAGS_MAINT_APPEND = -Wall
@@ -37,9 +35,3 @@ override_dh_auto_configure:
 	dh_auto_configure -- $(DEB_CMAKE_EXTRA_FLAGS) SHUTDOWN_NO_QUIT=YES LOCK_NO_QUIT=YES DISABLE_DEMO_VIDEO=YES DISABLE_TEXT_SHADOW=YES DISABLE_ANIMATIONS=YES USE_CURSOR_LOADING_ANI=YES
 endif
 
-ifeq ($(SYSTYPE), Professional)
-ifeq ($(DEB_BUILD_ARCH), amd64)
-override_dh_gencontrol:
-	dh_gencontrol -- -Vdist:Depends="pbis-open"
-endif
-endif


### PR DESCRIPTION
1. Remove the check that skips showing the touchscreen selection dialog when the device is already associated with a screen
2. Pass the touch UUID directly to TouchscreenSetting instead of pre- checking the touch map
3. Remove unused SYSTYPE variable and related build configuration in debian/rules
4. Remove pbis-open dependency generation for Professional amd64 builds

Influence:
1. Verify the touchscreen selection dialog appears during initialization even when the touchscreen is already associated
2. Test that the dialog correctly displays when launching with a touch device UUID argument
3. Verify the build succeeds without the removed SYSTYPE and pbis-open dependency configurations
4. Test on both Server and Desktop system types to ensure no regression
5. Verify that the touch association still works correctly after selecting a screen in the dialog

fix: 修复初始化不弹出触控屏选择框的问题

1. 移除了当触摸设备已关联屏幕时跳过显示选择对话框的检查逻辑
2. 直接将触摸 UUID 传递给 TouchscreenSetting，不再预先检查 touch map
3. 移除 debian/rules 中无用的 SYSTYPE 变量及相关构建配置
4. 移除 Professional amd64 构建中 pbis-open 依赖的生成逻辑

Influence:
1. 验证初始化时即使触摸设备已关联屏幕，触控屏选择对话框也能正常弹出
2. 测试使用触摸设备 UUID 参数启动时对话框能正确显示
3. 验证移除 SYSTYPE 和 pbis-open 依赖配置后构建正常成功
4. 在 Server 和 Desktop 系统类型上测试，确保无回归问题
5. 验证在对话框中选择屏幕后触摸关联功能仍能正常工作

PMS: BUG-369775