### PR TITLE
fix(dde-lowpower): fix null pointer crash when screenAt returns null …

### DIFF
--- a/dde-lowpower/src/window.cpp
+++ b/dde-lowpower/src/window.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -66,6 +66,13 @@ void Window::setupSize()
     setFixedSize(totalWidth, totalHeight);
 
     QScreen *screen = qApp->screenAt(QCursor::pos());
+    if (!screen) {
+        screen = qApp->primaryScreen();
+    }
+    if (!screen) {
+        return;
+    }
+
     const qreal ratio = screen->devicePixelRatio();
     m_image->setFixedSize(m_pix.size() / ratio);
     m_image->move(screen->geometry().center() - m_image->rect().center());


### PR DESCRIPTION
…on Wayland

1. Added null check for QScreen pointer returned by screenAt(QCursor::pos())
2. Fallback to primaryScreen() when screenAt fails on Wayland
3. Early return if no screen available at all
4. Prevents SIGSEGV when QCursor::pos() returns invalid position

Log: Fix dde-lowpower crash on Wayland due to null screen pointer
Influence: Fixes crash on Wayland when launching with --quit

fix(dde-lowpower): 修复 Wayland 下 screenAt 返回空指针导致的崩溃

1. 增加 screenAt 返回空指针的判空保护
2. 获取不到光标所在屏幕时降级到主屏
3. 所有屏幕都不可用时提前返回
4. 避免 QCursor::pos() 返回无效位置时触发 SIGSEGV

Log: 修复 Wayland 下 dde-lowpower 空指针崩溃
PMS: BUG-370187
Influence: 修复 Wayland 下启动崩溃

## Summary by Sourcery

Handle missing screen information more safely when sizing the low-power window to prevent crashes on Wayland.

Bug Fixes:
- Avoid crashes when QCursor::pos() yields a position without an associated screen by falling back to the primary screen and aborting when no screens are available.

Enhancements:
- Update the SPDX copyright years for the low-power window source file.