### PR TITLE
fix(dde-license-dialog): correct disabled-state button color in disclaimer dialog (bug 360973)

### DIFF
--- a/dde-license-dialog/src/content.cpp
+++ b/dde-license-dialog/src/content.cpp
@@ -292,20 +292,19 @@ void Content::updateWindowHeight()
 
 void Content::updateAcceptBtnPalette()
 {
-    const QString btnStyle = "QPushButton { background-color: rgba(0, 0, 0, 0.15); border: none; border-radius: 6px; }"
+    const QString cancelBtnStyle = "QPushButton { background-color: rgba(0, 0, 0, 0.15); border: none; border-radius: 6px; }"
                              "QPushButton:hover { background-color: rgba(0, 0, 0, 0.2); }"
                              "QPushButton:pressed { background-color: rgba(0, 0, 0, 0.25); }";
-    m_cancelBtn->setStyleSheet(btnStyle);
-    m_acceptBtn->setStyleSheet(btnStyle);
+    m_cancelBtn->setStyleSheet(cancelBtnStyle);
+
+    const QString acceptBtnStyle = "QPushButton { background-color: rgba(0, 0, 0, 0.15); border: none; border-radius: 6px; }"
+                                  "QPushButton:hover { background-color: rgba(0, 0, 0, 0.2); }"
+                                  "QPushButton:pressed { background-color: rgba(0, 0, 0, 0.25); }"
+                                  "QPushButton:disabled { background-color: rgba(0, 0, 0, 0.05); }";
+    m_acceptBtn->setStyleSheet(acceptBtnStyle);
 
     DPalette pa = m_acceptBtn->palette();
-    QColor highlightColor = pa.highlight().color();
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
-        highlightColor.setAlphaF(0.7);
-    } else {
-        highlightColor.setAlphaF(0.6);
-    }
-    pa.setColor(QPalette::Disabled, QPalette::ButtonText, highlightColor);
     pa.setColor(QPalette::Normal, QPalette::ButtonText, pa.highlight().color());
+    pa.setColor(QPalette::Disabled, QPalette::ButtonText, pa.color(QPalette::Disabled, QPalette::WindowText));
     m_acceptBtn->setPalette(pa);
 }


### PR DESCRIPTION
## Bug 360973

控制中心开启开发者模式免责声明框"确定"按钮活动色状态有误

### Root Cause

`Content::updateAcceptBtnPalette()` in `dde-license-dialog/src/content.cpp` set `QPalette::Disabled` ButtonText to the highlight (active) color, so the confirm button appeared active even before the user checked the agreement checkbox. The QSS also lacked a `:disabled` pseudo-state, so the disabled background was identical to the normal background.

### Fix

- Disabled ButtonText now uses the standard DTK disabled text color (`QPalette::Disabled, QPalette::WindowText`) instead of highlight.
- Added `QPushButton:disabled` rule to the accept-button QSS with a lighter background so the disabled state is visually distinct.
- Kept the Normal ButtonText as highlight color (active state after checking the agreement) so the enabled/disabled contrast is clear.

### Testing

- Verified compilation with `g++ -std=c++17 -fsyntax-only`.
- Both light and dark themes handled via `QPalette::Disabled, QPalette::WindowText` which adapts to the DTK theme.

Related: DDE-65 / bug 360973

## Summary by Sourcery

Correct the visual disabled state of the disclaimer dialog’s confirm button to avoid it appearing active before agreement.

Bug Fixes:
- Separate cancel and confirm button styles and add a disabled-state style for the confirm button with a distinct background.
- Use the standard DTK disabled text color for the confirm button instead of the highlight color when the button is disabled.